### PR TITLE
Add charge-distribution command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ casanovo-utils = "casanovoutils:main"
 mgf-utils = "casanovoutils.mgfutils:main"
 downsample-ms = "casanovoutils.downsample:main"
 graph-prec-cov = "casanovoutils.preccov:main"
+charge-distribution = "casanovoutils.charge_distribution:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/casanovoutils/charge_distribution.py
+++ b/src/casanovoutils/charge_distribution.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""Compute the global charge state distribution from an MGF file.
+
+Outputs:
+  1. A TSV with columns: charge, count
+  2. A bar chart (PNG) of the distribution.
+
+Requires: pyteomics, matplotlib
+"""
+
+import csv
+import sys
+
+import fire
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from pyteomics import mgf
+
+
+def count_charge_states(spectra):
+    """Count precursor charge states across spectra.
+
+    Parameters
+    ----------
+    spectra : iterable
+        Iterable of pyteomics spectrum dicts.
+
+    Returns
+    -------
+    dict[int, int]
+        Mapping of charge state to count.
+    """
+    counts = {}
+    for spectrum in spectra:
+        charge_raw = spectrum["params"].get("charge", [2])
+        charge = (
+            int(charge_raw[0]) if isinstance(charge_raw, list) else int(charge_raw)
+        )
+        counts[charge] = counts.get(charge, 0) + 1
+    return counts
+
+
+def charge_distribution(
+    mgf_file,
+    output_tsv="charge_distribution.tsv",
+    output_plot="charge_distribution.png",
+):
+    """Charge state distribution for an MGF file.
+
+    Parameters
+    ----------
+    mgf_file : str
+        Input MGF file.
+    output_tsv : str
+        Output TSV path (default: charge_distribution.tsv).
+    output_plot : str
+        Output bar chart path (default: charge_distribution.png).
+    """
+    counts = count_charge_states(mgf.MGF(mgf_file))
+
+    total = sum(counts.values())
+    print(f"Processed {total} spectra total.", file=sys.stderr)
+    for charge in sorted(counts):
+        print(f"  charge {charge}: {counts[charge]}", file=sys.stderr)
+
+    # -- TSV output (sorted by charge) ----------------------------------------
+    with open(output_tsv, "w", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(["charge", "count"])
+        for charge in sorted(counts):
+            w.writerow([charge, counts[charge]])
+    print(f"Wrote {output_tsv}", file=sys.stderr)
+
+    # -- Bar chart ------------------------------------------------------------
+    charges = sorted(counts)
+    vals = [counts[c] for c in charges]
+    fig, ax = plt.subplots(figsize=(7, 4))
+    ax.bar([str(c) for c in charges], vals, edgecolor="black", linewidth=0.5)
+    ax.set_xlabel("Charge state")
+    ax.set_ylabel("Number of spectra")
+    ax.set_title(f"Charge state distribution  (n={total:,})")
+    fig.tight_layout()
+    fig.savefig(output_plot, dpi=150)
+    plt.close(fig)
+    print(f"Wrote {output_plot}", file=sys.stderr)
+
+
+def main():
+    fire.Fire(charge_distribution)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/casanovoutils/charge_distribution.py
+++ b/src/casanovoutils/charge_distribution.py
@@ -28,17 +28,24 @@ def count_charge_states(spectra):
 
     Returns
     -------
-    dict[int, int]
+    counts : dict[int, int]
         Mapping of charge state to count.
+    n_skipped : int
+        Number of spectra skipped due to multiple charge states.
     """
     counts = {}
+    n_skipped = 0
     for spectrum in spectra:
         charge_raw = spectrum["params"].get("charge", [2])
-        charge = (
-            int(charge_raw[0]) if isinstance(charge_raw, list) else int(charge_raw)
-        )
+        if isinstance(charge_raw, list):
+            if len(charge_raw) != 1:
+                n_skipped += 1
+                continue
+            charge = int(charge_raw[0])
+        else:
+            charge = int(charge_raw)
         counts[charge] = counts.get(charge, 0) + 1
-    return counts
+    return counts, n_skipped
 
 
 def charge_distribution(
@@ -57,10 +64,17 @@ def charge_distribution(
     output_plot : str
         Output bar chart path (default: charge_distribution.png).
     """
-    counts = count_charge_states(mgf.MGF(mgf_file))
+    with mgf.MGF(mgf_file) as reader:
+        counts, n_skipped = count_charge_states(reader)
 
     total = sum(counts.values())
-    print(f"Processed {total} spectra total.", file=sys.stderr)
+    print(f"Processed {total + n_skipped} spectra total.", file=sys.stderr)
+    if n_skipped:
+        print(
+            f"  Warning: {n_skipped} spectra with multiple or missing charge"
+            " states were skipped.",
+            file=sys.stderr,
+        )
     for charge in sorted(counts):
         print(f"  charge {charge}: {counts[charge]}", file=sys.stderr)
 
@@ -79,7 +93,7 @@ def charge_distribution(
     ax.bar([str(c) for c in charges], vals, edgecolor="black", linewidth=0.5)
     ax.set_xlabel("Charge state")
     ax.set_ylabel("Number of spectra")
-    ax.set_title(f"Charge state distribution  (n={total:,})")
+    ax.set_title(f"Charge state distribution (n={total:,})")
     fig.tight_layout()
     fig.savefig(output_plot, dpi=150)
     plt.close(fig)

--- a/src/casanovoutils/charge_distribution.py
+++ b/src/casanovoutils/charge_distribution.py
@@ -14,9 +14,11 @@ from os import PathLike
 from typing import Iterable
 
 import fire
+# isort: off
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+# isort: on
 from pyteomics import mgf
 
 
@@ -81,8 +83,10 @@ def charge_distribution(
         print(f"  charge {charge}: {counts[charge]}", file=sys.stderr)
 
     if not counts:
-        print("  Warning: no spectra with valid charge states found.",
-              file=sys.stderr)
+        print(
+            "  Warning: no spectra with valid charge states found.",
+            file=sys.stderr,
+        )
 
     # -- TSV output (sorted by charge) ----------------------------------------
     with open(output_tsv, "w", newline="") as fh:

--- a/src/casanovoutils/charge_distribution.py
+++ b/src/casanovoutils/charge_distribution.py
@@ -33,12 +33,12 @@ def count_charge_states(spectra: Iterable) -> tuple[dict[int, int], int]:
     counts : dict[int, int]
         Mapping of charge state to count.
     n_skipped : int
-        Number of spectra skipped due to multiple charge states.
+        Number of spectra skipped (missing, empty, or multiple charge states).
     """
     counts = {}
     n_skipped = 0
     for spectrum in spectra:
-        charge_raw = spectrum["params"].get("charge", [2])
+        charge_raw = spectrum["params"].get("charge", [])
         if isinstance(charge_raw, list):
             if len(charge_raw) != 1:
                 n_skipped += 1
@@ -59,11 +59,11 @@ def charge_distribution(
 
     Parameters
     ----------
-    mgf_file : str
+    mgf_file : PathLike
         Input MGF file.
-    output_tsv : str
+    output_tsv : PathLike
         Output TSV path (default: charge_distribution.tsv).
-    output_plot : str
+    output_plot : PathLike
         Output bar chart path (default: charge_distribution.png).
     """
     with mgf.MGF(mgf_file) as reader:
@@ -79,6 +79,10 @@ def charge_distribution(
         )
     for charge in sorted(counts):
         print(f"  charge {charge}: {counts[charge]}", file=sys.stderr)
+
+    if not counts:
+        print("  Warning: no spectra with valid charge states found.",
+              file=sys.stderr)
 
     # -- TSV output (sorted by charge) ----------------------------------------
     with open(output_tsv, "w", newline="") as fh:

--- a/src/casanovoutils/charge_distribution.py
+++ b/src/casanovoutils/charge_distribution.py
@@ -10,6 +10,8 @@ Requires: pyteomics, matplotlib
 
 import csv
 import sys
+from os import PathLike
+from typing import Iterable
 
 import fire
 import matplotlib
@@ -18,7 +20,7 @@ import matplotlib.pyplot as plt
 from pyteomics import mgf
 
 
-def count_charge_states(spectra):
+def count_charge_states(spectra: Iterable) -> tuple[dict[int, int], int]:
     """Count precursor charge states across spectra.
 
     Parameters
@@ -49,10 +51,10 @@ def count_charge_states(spectra):
 
 
 def charge_distribution(
-    mgf_file,
-    output_tsv="charge_distribution.tsv",
-    output_plot="charge_distribution.png",
-):
+    mgf_file: PathLike,
+    output_tsv: PathLike = "charge_distribution.tsv",
+    output_plot: PathLike = "charge_distribution.png",
+) -> None:
     """Charge state distribution for an MGF file.
 
     Parameters
@@ -100,7 +102,7 @@ def charge_distribution(
     print(f"Wrote {output_plot}", file=sys.stderr)
 
 
-def main():
+def main() -> None:
     fire.Fire(charge_distribution)
 
 

--- a/tests/test_charge_distribution.py
+++ b/tests/test_charge_distribution.py
@@ -1,7 +1,4 @@
 import csv
-import pathlib
-
-import pytest
 
 from casanovoutils.charge_distribution import count_charge_states, charge_distribution
 
@@ -71,6 +68,17 @@ def test_count_charge_states_empty_charge_list_skipped():
     ]
     counts, n_skipped = count_charge_states(spectra)
     assert counts == {2: 1}
+    assert n_skipped == 1
+
+
+def test_count_charge_states_missing_charge_skipped():
+    """Spectra with no charge key are skipped."""
+    spectra = [
+        {"params": {}},  # no charge key — skip
+        _spectrum(3),
+    ]
+    counts, n_skipped = count_charge_states(spectra)
+    assert counts == {3: 1}
     assert n_skipped == 1
 
 

--- a/tests/test_charge_distribution.py
+++ b/tests/test_charge_distribution.py
@@ -1,0 +1,91 @@
+import csv
+import pathlib
+
+import pytest
+
+from casanovoutils.charge_distribution import count_charge_states, charge_distribution
+
+
+# ---------------------------------------------------------------------------
+# count_charge_states tests (pure function)
+# ---------------------------------------------------------------------------
+
+
+def _spectrum(charge):
+    """Create a minimal spectrum dict with the given charge."""
+    return {"params": {"charge": [charge]}}
+
+
+def test_count_charge_states_mixed():
+    """Multiple spectra with mixed charges produce correct counts."""
+    spectra = [_spectrum(2), _spectrum(3), _spectrum(2), _spectrum(4), _spectrum(3)]
+    counts = count_charge_states(spectra)
+    assert counts == {2: 2, 3: 2, 4: 1}
+
+
+def test_count_charge_states_single():
+    """All spectra with the same charge produce a single entry."""
+    spectra = [_spectrum(2), _spectrum(2), _spectrum(2)]
+    counts = count_charge_states(spectra)
+    assert counts == {2: 3}
+
+
+def test_count_charge_states_empty():
+    """Empty input produces an empty dict."""
+    assert count_charge_states([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+SMALL_MGF = """\
+BEGIN IONS
+TITLE=spec1
+PEPMASS=500.0
+CHARGE=2+
+100.0 10
+200.0 20
+END IONS
+
+BEGIN IONS
+TITLE=spec2
+PEPMASS=600.0
+CHARGE=3+
+150.0 15
+250.0 25
+END IONS
+
+BEGIN IONS
+TITLE=spec3
+PEPMASS=700.0
+CHARGE=2+
+120.0 12
+220.0 22
+END IONS
+"""
+
+
+def test_charge_distribution_integration(tmp_path):
+    """CLI function writes expected TSV and PNG."""
+    mgf_path = tmp_path / "test.mgf"
+    mgf_path.write_text(SMALL_MGF)
+
+    tsv_path = tmp_path / "out.tsv"
+    png_path = tmp_path / "out.png"
+
+    charge_distribution(str(mgf_path), str(tsv_path), str(png_path))
+
+    # Check TSV contents
+    with open(tsv_path) as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        rows = list(reader)
+    assert len(rows) == 2
+    assert rows[0]["charge"] == "2"
+    assert rows[0]["count"] == "2"
+    assert rows[1]["charge"] == "3"
+    assert rows[1]["count"] == "1"
+
+    # Check PNG exists and is non-empty
+    assert png_path.exists()
+    assert png_path.stat().st_size > 0

--- a/tests/test_charge_distribution.py
+++ b/tests/test_charge_distribution.py
@@ -12,27 +12,66 @@ from casanovoutils.charge_distribution import count_charge_states, charge_distri
 
 
 def _spectrum(charge):
-    """Create a minimal spectrum dict with the given charge."""
+    """Create a minimal spectrum dict with the given charge (as a list)."""
     return {"params": {"charge": [charge]}}
 
 
 def test_count_charge_states_mixed():
     """Multiple spectra with mixed charges produce correct counts."""
     spectra = [_spectrum(2), _spectrum(3), _spectrum(2), _spectrum(4), _spectrum(3)]
-    counts = count_charge_states(spectra)
+    counts, n_skipped = count_charge_states(spectra)
     assert counts == {2: 2, 3: 2, 4: 1}
+    assert n_skipped == 0
 
 
 def test_count_charge_states_single():
     """All spectra with the same charge produce a single entry."""
     spectra = [_spectrum(2), _spectrum(2), _spectrum(2)]
-    counts = count_charge_states(spectra)
+    counts, n_skipped = count_charge_states(spectra)
     assert counts == {2: 3}
+    assert n_skipped == 0
 
 
 def test_count_charge_states_empty():
     """Empty input produces an empty dict."""
-    assert count_charge_states([]) == {}
+    counts, n_skipped = count_charge_states([])
+    assert counts == {}
+    assert n_skipped == 0
+
+
+def test_count_charge_states_scalar_charge():
+    """Charge returned as a single integer (not a list) is handled."""
+    spectra = [
+        {"params": {"charge": 2}},
+        {"params": {"charge": 3}},
+        {"params": {"charge": 2}},
+    ]
+    counts, n_skipped = count_charge_states(spectra)
+    assert counts == {2: 2, 3: 1}
+    assert n_skipped == 0
+
+
+def test_count_charge_states_multiple_charges_skipped():
+    """Spectra with multiple charge states are skipped."""
+    spectra = [
+        _spectrum(2),
+        {"params": {"charge": [2, 3]}},  # ambiguous — skip
+        _spectrum(3),
+    ]
+    counts, n_skipped = count_charge_states(spectra)
+    assert counts == {2: 1, 3: 1}
+    assert n_skipped == 1
+
+
+def test_count_charge_states_empty_charge_list_skipped():
+    """Spectra with an empty charge list are skipped."""
+    spectra = [
+        _spectrum(2),
+        {"params": {"charge": []}},  # empty — skip
+    ]
+    counts, n_skipped = count_charge_states(spectra)
+    assert counts == {2: 1}
+    assert n_skipped == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New CLI command `charge-distribution` that reads an MGF file and computes a global charge state distribution
- Outputs a TSV with charge/count columns and a bar chart PNG
- Includes unit tests for the pure function and an integration test

## Test plan
- [x] `pytest tests/test_charge_distribution.py -v` — all 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a charge-distribution command-line tool to analyze charge‑state distributions from MGF files; produces a TSV summary and a PNG bar‑chart, prints progress and per‑charge summaries, and reports skipped/ambiguous spectra.
* **Tests**
  * Added unit tests for charge counting and integration tests that run the CLI, verify TSV contents, and ensure PNG output is produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->