### PR TITLE
Fix I/L equivalence and AUPC calculation in evaluate.py

### DIFF
--- a/src/casanovoutils/evaluate.py
+++ b/src/casanovoutils/evaluate.py
@@ -63,17 +63,20 @@ def get_ground_truth(
         - ``ground_truth`` (string dtype)
             Ground-truth peptide sequence from the MGF.
 
-        - All columns from the MzTab PSM table
-            These are inserted at the spectrum indices specified by
-            ``spectra_ref``. Rows without a corresponding PSM retain missing
-            values.
+        - ``predicted`` (string dtype)
+            Predicted peptide sequence from the MzTab. Empty string for
+            spectra with no corresponding PSM row.
 
-        - ``pep_correct`` (boolean)
+        - ``pep_score`` (float64)
+            Per-PSM confidence score from the MzTab. Set to ``MIN_PEP_SCORE``
+            for spectra with no corresponding PSM row.
+
+        - ``pep_correct`` (bool)
             Exact-match correctness label computed as::
 
-                ground_truth == sequence
+                ground_truth == predicted
 
-            after optional I/L replacement.
+            after optional I/L replacement in both columns.
     """
     if not isinstance(mztab_path, pd.DataFrame):
         psm_df = pyteomics.mztab.MzTab(mztab_path).spectrum_match_table
@@ -90,31 +93,33 @@ def get_ground_truth(
         psm_df["spectra_ref"].str[len("ms_run[1]:index=") :].apply(int).to_numpy()
     )
 
-    predictions_df = pd.DataFrame({"ground_truth": ground_truth})
+    n = len(ground_truth)
+    predictions_df = pd.DataFrame(
+        {
+            "ground_truth": pd.array(ground_truth, dtype="string"),
+            "predicted": pd.array([""] * n, dtype="string"),
+            "pep_score": pd.array([MIN_PEP_SCORE] * n, dtype="float64"),
+        }
+    )
 
-    for col in psm_df.columns:
-        if col == "sequence":
-            predictions_df[col] = pd.Series(
-                "", index=range(len(ground_truth)), dtype="string"
-            )
-        elif col == "search_engine_score[1]":
-            predictions_df[col] = pd.Series(
-                MIN_PEP_SCORE, index=range(len(ground_truth)), dtype="float64"
-            )
-        else:
-            predictions_df[col] = None
-
-        col_idx = predictions_df.columns.get_loc(col)
-        predictions_df.iloc[spectra_idx, col_idx] = psm_df[col]
+    predicted_idx = predictions_df.columns.get_loc("predicted")
+    pep_score_idx = predictions_df.columns.get_loc("pep_score")
+    predictions_df.iloc[spectra_idx, predicted_idx] = psm_df["sequence"].to_numpy()
+    predictions_df.iloc[spectra_idx, pep_score_idx] = psm_df[
+        "search_engine_score[1]"
+    ].to_numpy()
 
     if replace_i_l:
         predictions_df["ground_truth"] = predictions_df["ground_truth"].str.replace(
-            "I", "L"
+            "I", "L", regex=False
+        )
+        predictions_df["predicted"] = predictions_df["predicted"].str.replace(
+            "I", "L", regex=False
         )
 
     predictions_df["pep_correct"] = (
-        predictions_df["ground_truth"] == predictions_df["sequence"]
-    )
+        predictions_df["ground_truth"] == predictions_df["predicted"]
+    ).astype(bool)
 
     return predictions_df
 
@@ -155,5 +160,8 @@ def prec_cov(
 
     precision = total_precision / total_coverage
     coverage = total_coverage / total_coverage[-1]
-    aupc = np.trapz(precision, coverage)
+    aupc = np.trapz(
+        np.concatenate([[precision[0]], precision]),
+        np.concatenate([[0.0], coverage]),
+    )
     return precision, coverage, aupc

--- a/src/casanovoutils/evaluate.py
+++ b/src/casanovoutils/evaluate.py
@@ -83,6 +83,14 @@ def get_ground_truth(
     else:
         psm_df = mztab_path
 
+    required = {"spectra_ref", "sequence", "search_engine_score[1]"}
+    missing = required - set(psm_df.columns)
+    if missing:
+        raise ValueError(
+            f"PSM table is missing required column(s): {sorted(missing)}. "
+            f"Expected columns: {sorted(required)}."
+        )
+
     ground_truth = []
     with open(mgf_path) as f:
         for line in tqdm.tqdm(f, desc=f"Reading mgf file: {mgf_path}", unit="lines"):

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -84,25 +84,22 @@ def test_get_ground_truth_dataframe_aligns_by_spectra_index(tmp_path):
     assert out["pep_correct"].tolist() == [False, True, False, False, False]
 
 
-def test_get_ground_truth_replace_i_l_bug_is_exposed(tmp_path):
+def test_get_ground_truth_replace_i_l(tmp_path):
     """
-    The current implementation calls .str.replace(...) without assignment,
-    so replace_i_l=True should NOT change behavior (this test locks in the bug).
-
-    If you later fix the bug, update/flip this test accordingly.
+    With replace_i_l=True, I and L are treated as equivalent: ground truth
+    "ILIL" should match prediction "LLLL" after I->L substitution in both.
+    Without replacement, "ILIL" != "LLLL" so pep_correct should be False.
     """
     mgf_seqs = ["ILIL", "LLLL"]
     mgf_path = _write_mgf(tmp_path, mgf_seqs)
 
-    # Predict "LLLL" for spectrum 0; would become correct if I->L replacement worked.
     psm = _psm_df(indices=[0], sequences=["LLLL"], scores=[1.0])
 
     out_no_replace = get_ground_truth(psm, mgf_path, replace_i_l=False)
     out_replace = get_ground_truth(psm, mgf_path, replace_i_l=True)
 
-    # Both should be incorrect for row 0 given the current bug
-    assert out_no_replace.loc[0, "pep_correct"] is False
-    assert out_replace.loc[0, "pep_correct"] is False
+    assert not out_no_replace.loc[0, "pep_correct"]
+    assert out_replace.loc[0, "pep_correct"]
 
 
 def test_get_ground_truth_raises_on_bad_spectra_ref_format(tmp_path):
@@ -148,7 +145,7 @@ def test_get_ground_truth_mztab_path_uses_pyteomics_reader(monkeypatch, tmp_path
 
     assert out.loc[2, "predicted"] == "CCC"
     assert float(out.loc[2, "pep_score"]) == 9.0
-    assert out.loc[2, "pep_correct"] is True
+    assert out.loc[2, "pep_correct"]
 
 
 # -------------------------


### PR DESCRIPTION
## Summary

- Fix `get_ground_truth()` output column names to `predicted` and `pep_score` (was `sequence` and `search_engine_score[1]`), which was causing the `graph-prec-cov` tool to fail end-to-end
- Apply I/L replacement to both `ground_truth` and `predicted` columns (was only applied to `ground_truth`); add `regex=False` to suppress pandas deprecation warning
- Fix AUPC integration in `prec_cov()` to start from `coverage=0`, correcting an off-by-one error that gave `(n-1)/n` instead of `1.0` for an all-correct model
- Update tests to reflect correct post-fix behavior; replace `is True`/`is False` with `assert`/`assert not` to handle numpy `bool_` scalars correctly

## Test plan

- [ ] All 8 tests in `tests/test_evaluate.py` pass
- [ ] Verify `graph-prec-cov` runs end-to-end on a real mzTab + MGF pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed isoleucine/leucine equivalence handling in sequence comparison

* **Refactor**
  * Streamlined PSM evaluation output schema to essential columns (ground truth, predicted, score, correctness)
  * Enhanced prediction alignment and matching logic
  * Improved precision-coverage area calculation methodology
  * Updated correctness computation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->