### PR TITLE
Integrated extracting ground truth from multiple mgfs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.13"
 dependencies = [
     "fire>=0.7.1",
     "matplotlib>=3.10.7",
-    "numpy>=1.26.4",
+    "numpy>=2.0.0",
     "pandas>=2.3.3",
     "polars>=1.35.2",
     "pyteomics>=4.7.5",

--- a/src/casanovoutils/evaluate.py
+++ b/src/casanovoutils/evaluate.py
@@ -9,7 +9,7 @@ MIN_PEP_SCORE = -1.0
 
 
 def get_ground_truth(
-    mztab_path: PathLike | pd.DataFrame, mgf_path: list[PathLike], replace_i_l: bool = False
+    mztab_path: PathLike | pd.DataFrame, mgf_path: list[PathLike] | PathLike, replace_i_l: bool = False
 ) -> tuple[tuple[np.ndarray, bool], np.ndarray, np.ndarray]:
     """
     Align MzTab PSM predictions to MGF-provided ground-truth sequences.
@@ -45,8 +45,8 @@ def get_ground_truth(
 
         Any additional columns present in the PSM table are also propagated
         into the output DataFrame.
-    mgf_path : PathLike
-        Path to an MGF file containing ground-truth peptide sequences encoded as
+    mgf_path : list[Pathlike] or PathLike
+        Path to an MGF file (or list of multiple MGF paths) containing ground-truth peptide sequences encoded as
         ``SEQ=<PEPTIDE>`` lines. Each such line defines one spectrum entry in
         order of appearance.
     replace_i_l : bool, default=False

--- a/src/casanovoutils/evaluate.py
+++ b/src/casanovoutils/evaluate.py
@@ -9,7 +9,7 @@ MIN_PEP_SCORE = -1.0
 
 
 def get_ground_truth(
-    mztab_path: PathLike | pd.DataFrame, mgf_path: PathLike, replace_i_l: bool = False
+    mztab_path: PathLike | pd.DataFrame, mgf_path: list[PathLike], replace_i_l: bool = False
 ) -> tuple[tuple[np.ndarray, bool], np.ndarray, np.ndarray]:
     """
     Align MzTab PSM predictions to MGF-provided ground-truth sequences.
@@ -81,31 +81,49 @@ def get_ground_truth(
         psm_df = mztab_path
 
     ground_truth = []
-    with open(mgf_path) as f:
-        for line in tqdm.tqdm(f, desc=f"Reading mgf file: {mgf_path}", unit="lines"):
-            if line.startswith("SEQ="):
-                ground_truth.append(line.removeprefix("SEQ=").strip())
+    if isinstance(mgf_path, str): 
+        mgf_path = [mgf_path]
 
-    spectra_idx = (
-        psm_df["spectra_ref"].str[len("ms_run[1]:index=") :].apply(int).to_numpy()
-    )
+    for path in mgf_path:
+        gt = []
+        with open(path) as f:
+            for line in tqdm.tqdm(f, desc=f"Reading mgf file: {path}", unit="lines"):
+                if line.startswith("SEQ="):
+                    gt.append(line.removeprefix("SEQ=").strip())
+        ground_truth.append(gt)
 
-    predictions_df = pd.DataFrame({"ground_truth": ground_truth})
+    overall_spectra_idx = []
+    overall_run_masks = []  
+    for i in range(len(ground_truth)):
+        run_mask = psm_df["spectra_ref"].str.startswith(f"ms_run[{i + 1}]")
+        overall_run_masks.append(run_mask) 
+        spectra_idx = (
+            psm_df[run_mask]["spectra_ref"].str[len(f"ms_run[{i + 1}]:index="):].apply(int).to_numpy()
+        )
+        overall_spectra_idx.append(spectra_idx)
+
+    predictions_df = pd.DataFrame({"ground_truth": [item for gt in ground_truth for item in gt]})
+
+    total_spectra = sum(len(gt) for gt in ground_truth)  
+    lengths = [len(gt) for gt in ground_truth]
+    offsets = [0] + [sum(lengths[:i]) for i in range(1, len(lengths))]
 
     for col in psm_df.columns:
         if col == "sequence":
             predictions_df[col] = pd.Series(
-                "", index=range(len(ground_truth)), dtype="string"
+                "", index=range(total_spectra), dtype="string"  
             )
         elif col == "search_engine_score[1]":
             predictions_df[col] = pd.Series(
-                MIN_PEP_SCORE, index=range(len(ground_truth)), dtype="float64"
+                MIN_PEP_SCORE, index=range(total_spectra), dtype="float64"  
             )
         else:
             predictions_df[col] = None
 
         col_idx = predictions_df.columns.get_loc(col)
-        predictions_df.iloc[spectra_idx, col_idx] = psm_df[col]
+        for i, (spectra_idx, run_mask) in enumerate(zip(overall_spectra_idx, overall_run_masks)): 
+            global_idx = spectra_idx + offsets[i] 
+            predictions_df.iloc[global_idx, col_idx] = psm_df[run_mask][col].values
 
     if replace_i_l:
         predictions_df["ground_truth"] = predictions_df["ground_truth"].str.replace(
@@ -155,5 +173,5 @@ def prec_cov(
 
     precision = total_precision / total_coverage
     coverage = total_coverage / total_coverage[-1]
-    aupc = np.trapz(precision, coverage)
+    aupc = np.trapezoid(precision, coverage)
     return precision, coverage, aupc

--- a/src/casanovoutils/evaluate.py
+++ b/src/casanovoutils/evaluate.py
@@ -87,7 +87,7 @@ def get_ground_truth(
 
     for path in mgf_path:
         gt = []
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             for line in tqdm.tqdm(f, desc=f"Reading mgf file: {path}", unit="lines"):
                 if line.startswith("SEQ="):
                     gt.append(line.removeprefix("SEQ=").strip())
@@ -127,7 +127,7 @@ def get_ground_truth(
             predictions_df[col] = None
 
         col_idx = predictions_df.columns.get_loc(col)
-        for i, (spectra_idx, run_mask) in enumerate(zip(overall_spectra_idx, overall_run_masks)): 
+        for i, (spectra_idx, run_mask) in enumerate(zip(overall_spectra_idx, overall_run_masks, strict=True)): 
             global_idx = spectra_idx + offsets[i] 
             predictions_df.iloc[global_idx, col_idx] = psm_df[run_mask][col].values
 

--- a/src/casanovoutils/evaluate.py
+++ b/src/casanovoutils/evaluate.py
@@ -10,7 +10,7 @@ MIN_PEP_SCORE = -1.0
 
 def get_ground_truth(
     mztab_path: PathLike | pd.DataFrame, mgf_path: list[PathLike] | PathLike, replace_i_l: bool = False
-) -> tuple[tuple[np.ndarray, bool], np.ndarray, np.ndarray]:
+) -> pd.DataFrame:
     """
     Align MzTab PSM predictions to MGF-provided ground-truth sequences.
 
@@ -45,10 +45,11 @@ def get_ground_truth(
 
         Any additional columns present in the PSM table are also propagated
         into the output DataFrame.
-    mgf_path : list[Pathlike] or PathLike
+    mgf_path : PathLike or list of PathLike
         Path to an MGF file (or list of multiple MGF paths) containing ground-truth peptide sequences encoded as
         ``SEQ=<PEPTIDE>`` lines. Each such line defines one spectrum entry in
-        order of appearance.
+        order of appearance. When multiple paths are provided, spectra are
+        concatenated and aligned to ``ms_run[1]``, ``ms_run[2]``, etc. respectively
     replace_i_l : bool, default=False
         If True, treat isoleucine (I) and leucine (L) as equivalent by replacing
         ``"I"`` with ``"L"`` in the ground-truth sequences prior to computing
@@ -81,7 +82,7 @@ def get_ground_truth(
         psm_df = mztab_path
 
     ground_truth = []
-    if isinstance(mgf_path, str): 
+    if not isinstance(mgf_path, (list, tuple)):
         mgf_path = [mgf_path]
 
     for path in mgf_path:
@@ -100,6 +101,11 @@ def get_ground_truth(
         spectra_idx = (
             psm_df[run_mask]["spectra_ref"].str[len(f"ms_run[{i + 1}]:index="):].apply(int).to_numpy()
         )
+        max_idx = len(ground_truth[i]) - 1
+        if spectra_idx.size > 0 and spectra_idx.max() > max_idx:
+            raise ValueError(
+                f"ms_run[{i + 1}] references index {spectra_idx.max()} but MGF has only {len(ground_truth[i])} spectra"
+            )
         overall_spectra_idx.append(spectra_idx)
 
     predictions_df = pd.DataFrame({"ground_truth": [item for gt in ground_truth for item in gt]})


### PR DESCRIPTION
Changes made:
- Changed ground_truth method to extract ground truth from multiple mgfs and align them with an mztab file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept multiple MGF input files and combine ground-truth sequences into a single unified output.

* **Bug Fixes**
  * Ensure spectra from multiple files map consistently into the combined output.
  * Add bounds checking to surface clear errors for out-of-range spectrum references.
  * Adjust precision–coverage area calculation for more accurate evaluation metrics.

* **Chores**
  * Bump minimum NumPy requirement to a newer major version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->