### PR TITLE
Spectrum peaks

### DIFF
--- a/src/casanovoutils/utils.py
+++ b/src/casanovoutils/utils.py
@@ -133,7 +133,9 @@ def get_mgf_psms_df(
     logging.info("Reading MGF file %s", str(mgf_path))
     mgf_iter = pyteomics.mgf.read(str(mgf_path), use_index=False, convert_arrays=0)
     mgf_iter = tqdm.tqdm(mgf_iter, desc="reading params", unit="spectra")
-    mgf_iter = map(lambda x: process_spectrum(x, meta_data_only), mgf_iter)
+    mgf_iter = map(
+        lambda x: process_spectrum(x, meta_data_only=meta_data_only), mgf_iter
+    )
 
     spectrum_df = pl.from_dicts(mgf_iter)
     logging.info("Read %d spectra from %s", len(spectrum_df), str(mgf_path))

--- a/src/casanovoutils/utils.py
+++ b/src/casanovoutils/utils.py
@@ -17,26 +17,40 @@ PyteomicsSpectrum = dict[str, dict[str, Any] | list[Any]]
 DfPath = PathLike | pl.DataFrame
 
 
-def process_spectrum(spectrum: PyteomicsSpectrum) -> dict[str, dict[str, Any]]:
+def process_spectrum(
+    spectrum: PyteomicsSpectrum, meta_data_only: bool = True
+) -> dict[str, dict[str, Any]]:
     """
     Extract and augment parameter metadata from a single spectrum.
 
     Retrieves the ``params`` dict from a Pyteomics spectrum object and
-    annotates it with the number of peaks in the spectrum.
+    annotates it with the number of peaks in the spectrum. If ``meta_data_only``
+    is ``False``, the intensity and m/z arrays are also included in the output.
 
     Parameters
     ----------
     spectrum : PyteomicsSpectrum
         A spectrum dict as returned by ``pyteomics.mgf.read``, containing
-        at least a ``"params"`` key and an ``"m/z array"`` key.
+        at least a ``"params"`` key, an ``"m/z array"`` key, and an
+        ``"intensity array"`` key.
+    meta_data_only : bool, optional
+        If ``True``, only scalar metadata is returned (no spectral arrays).
+        If ``False``, ``"intensity_array"`` and ``"m_z_array"`` are added
+        to the output dict.
 
     Returns
     -------
-    dict[str, dict[str, Any]]
-        The spectrum's parameter dict with an added ``"n_peaks"`` entry.
+    dict[str, Any]
+        The spectrum's parameter dict with an added ``"n_peaks"`` entry, and
+        optionally ``"intensity_array"`` and ``"m_z_array"`` entries.
     """
     params = spectrum["params"]
     params["n_peaks"] = len(spectrum["m/z array"])
+
+    if not meta_data_only:
+        params["intensity_array"] = spectrum["intensity array"]
+        params["m_z_array"] = spectrum["m/z array"]
+
     return params
 
 
@@ -70,15 +84,17 @@ def write_dataframe(data_df: pl.DataFrame, out_path: PathLike) -> None:
 
 
 def get_mgf_psms_df(
-    mgf_path: DfPath, out_path: Optional[PathLike] = None
+    mgf_path: DfPath,
+    out_path: Optional[PathLike] = None,
+    meta_data_only: bool = True,
 ) -> pl.DataFrame:
     """
     Load PSM metadata from an MGF file into a Polars DataFrame.
 
-    If ``mgf_path`` is already a DataFrame, it is returned as-is.
-    Otherwise, the MGF file is parsed with Pyteomics, spectrum parameters
-    are extracted via :func:`process_spectrum`, and all columns are prefixed
-    with ``mgf_``.
+    If ``mgf_path`` is already a :class:`polars.DataFrame`, it is returned
+    as-is (and optionally written to ``out_path``). Otherwise, the MGF file
+    is parsed with Pyteomics, per-spectrum parameters are extracted via
+    :func:`process_spectrum`, and all columns are prefixed with ``mgf_``.
 
     Parameters
     ----------
@@ -86,13 +102,25 @@ def get_mgf_psms_df(
         Path to an MGF file, or an already-loaded :class:`polars.DataFrame`.
     out_path : PathLike, optional
         If provided, the resulting DataFrame is written to this path before
-        being returned. The format is inferred from the file extension.
+        being returned. The format is inferred from the file extension via
+        :func:`write_dataframe`.
+    meta_data_only : bool, optional
+        Passed through to :func:`process_spectrum`. If ``True`` (default),
+        only scalar spectrum metadata is loaded (no m/z or intensity arrays).
+        If ``False``, ``mgf_intensity_array`` and ``mgf_m_z_array`` columns
+        are included in the returned DataFrame.
 
     Returns
     -------
     pl.DataFrame
         A DataFrame with one row per spectrum and columns prefixed with
         ``mgf_``, including an ``mgf_n_peaks`` column.
+
+    Raises
+    ------
+    ValueError
+        Propagated from :func:`write_dataframe` if ``out_path`` has an
+        unsupported file extension.
     """
     if isinstance(mgf_path, pl.DataFrame):
         if out_path is not None:
@@ -105,7 +133,7 @@ def get_mgf_psms_df(
     logging.info("Reading MGF file %s", str(mgf_path))
     mgf_iter = pyteomics.mgf.read(str(mgf_path), use_index=False, convert_arrays=0)
     mgf_iter = tqdm.tqdm(mgf_iter, desc="reading params", unit="spectra")
-    mgf_iter = map(process_spectrum, mgf_iter)
+    mgf_iter = map(lambda x: process_spectrum(x, meta_data_only), mgf_iter)
 
     spectrum_df = pl.from_dicts(mgf_iter)
     logging.info("Read %d spectra from %s", len(spectrum_df), str(mgf_path))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,3 +140,117 @@ def test_get_ground_truth_df_writes_output(tmp_path, mgf_df, mztab_df):
     out_path = tmp_path / "out.parquet"
     get_ground_truth_df(mgf_df, mztab_df, out_path=out_path)
     assert out_path.exists()
+
+
+def test_process_spectrum_meta_data_only_excludes_arrays():
+    spectrum = {
+        "params": {"title": "spec1"},
+        "m/z array": [1.0, 2.0],
+        "intensity array": [100.0, 200.0],
+    }
+    result = process_spectrum(spectrum, meta_data_only=True)
+    assert "m_z_array" not in result
+    assert "intensity_array" not in result
+
+
+def test_process_spectrum_not_meta_data_only_includes_arrays():
+    spectrum = {
+        "params": {"title": "spec1"},
+        "m/z array": [1.0, 2.0],
+        "intensity array": [100.0, 200.0],
+    }
+    result = process_spectrum(spectrum, meta_data_only=False)
+    assert "m_z_array" in result
+    assert "intensity_array" in result
+
+
+def test_process_spectrum_not_meta_data_only_array_values():
+    mz = [1.0, 2.0, 3.0]
+    intensities = [100.0, 200.0, 300.0]
+    spectrum = {
+        "params": {},
+        "m/z array": mz,
+        "intensity array": intensities,
+    }
+    result = process_spectrum(spectrum, meta_data_only=False)
+    assert result["m_z_array"] == mz
+    assert result["intensity_array"] == intensities
+
+
+def test_process_spectrum_not_meta_data_only_still_adds_n_peaks():
+    spectrum = {
+        "params": {},
+        "m/z array": [1.0, 2.0],
+        "intensity array": [100.0, 200.0],
+    }
+    result = process_spectrum(spectrum, meta_data_only=False)
+    assert result["n_peaks"] == 2
+
+
+def test_process_spectrum_meta_data_only_default_is_true():
+    """meta_data_only should default to True — arrays must be absent when omitted."""
+    spectrum = {
+        "params": {},
+        "m/z array": [1.0],
+        "intensity array": [100.0],
+    }
+    # existing tests call process_spectrum without meta_data_only;
+    # confirm the default behaviour matches meta_data_only=True
+    result = process_spectrum(spectrum)
+    assert "m_z_array" not in result
+    assert "intensity_array" not in result
+
+
+def test_get_mgf_psms_df_passthrough_ignores_meta_data_only(simple_df):
+    """When a DataFrame is passed directly, meta_data_only has no effect."""
+    result = get_mgf_psms_df(simple_df, meta_data_only=False)
+    assert result is simple_df
+
+
+def test_get_mgf_psms_df_meta_data_only_excludes_array_columns(tmp_path):
+    mgf_content = (
+        "BEGIN IONS\n" "TITLE=spec1\n" "100.0 500.0\n" "200.0 300.0\n" "END IONS\n"
+    )
+    mgf_path = tmp_path / "test.mgf"
+    mgf_path.write_text(mgf_content)
+
+    result = get_mgf_psms_df(mgf_path, meta_data_only=True)
+    assert "mgf_m_z_array" not in result.columns
+    assert "mgf_intensity_array" not in result.columns
+
+
+def test_get_mgf_psms_df_not_meta_data_only_includes_array_columns(tmp_path):
+    mgf_content = (
+        "BEGIN IONS\n" "TITLE=spec1\n" "100.0 500.0\n" "200.0 300.0\n" "END IONS\n"
+    )
+    mgf_path = tmp_path / "test.mgf"
+    mgf_path.write_text(mgf_content)
+
+    result = get_mgf_psms_df(mgf_path, meta_data_only=False)
+    assert "mgf_m_z_array" in result.columns
+    assert "mgf_intensity_array" in result.columns
+
+
+def test_get_mgf_psms_df_n_peaks_correct_from_file(tmp_path):
+    mgf_content = (
+        "BEGIN IONS\n"
+        "TITLE=spec1\n"
+        "100.0 500.0\n"
+        "200.0 300.0\n"
+        "300.0 100.0\n"
+        "END IONS\n"
+    )
+    mgf_path = tmp_path / "test.mgf"
+    mgf_path.write_text(mgf_content)
+
+    result = get_mgf_psms_df(mgf_path, meta_data_only=True)
+    assert result["mgf_n_peaks"][0] == 3
+
+
+def test_get_mgf_psms_df_columns_have_mgf_prefix(tmp_path):
+    mgf_content = "BEGIN IONS\n" "TITLE=spec1\n" "100.0 500.0\n" "END IONS\n"
+    mgf_path = tmp_path / "test.mgf"
+    mgf_path.write_text(mgf_content)
+
+    result = get_mgf_psms_df(mgf_path)
+    assert all(c.startswith("mgf_") for c in result.columns)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional parameter to control whether spectrum processing includes detailed spectral array information (intensity values and m/z data) alongside metadata. By default, only scalar metadata is returned, maintaining backward compatibility. Users can now choose to include full spectral arrays when needed.

* **Tests**
  * Added comprehensive test coverage for the new spectrum data filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->