### PR TITLE
Add streaming downsample-spectra and spectra-per-peptide commands

### DIFF
--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -342,10 +342,171 @@ def pipeline(
     return result
 
 
+_VALID_DOWNSAMPLE_TYPES = frozenset({"number", "proportion"})
+
+
+def spectra_per_peptide(
+    spectra: SpectraInput,
+    k: int = 1,
+    outfile: Optional[PathLike] = None,
+    random_seed: int = 42,
+) -> list[PyteomicsSpectrum]:
+    """
+    Sample up to k spectra per peptide using reservoir sampling.
+
+    Makes a single streaming pass through *spectra*, maintaining a reservoir
+    of size k per unique peptide sequence.  For the j-th occurrence of a
+    peptide: if j <= k, add unconditionally; if j > k, replace a uniformly
+    random reservoir slot with probability k/j.  Memory usage is
+    O(unique peptides × k) rather than O(total spectra).
+
+    Parameters
+    ----------
+    spectra : PathLike, Iterable[PathLike], or Iterable[PyteomicsSpectrum]
+        Spectrum source — see :func:`iter_spectra` for accepted types.
+    k : int, default=1
+        Maximum number of spectra to retain per peptide sequence.
+    outfile : PathLike, optional
+        If provided, write the sampled spectra to this MGF file path.
+    random_seed : int, default=42
+        Seed for the local random number generator.
+
+    Returns
+    -------
+    list[PyteomicsSpectrum]
+        Sampled spectra, grouped by peptide in first-seen order.
+    """
+    configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
+    logging.info(
+        "Sampling up to k=%d spectra per peptide (random_seed=%d)", k, random_seed
+    )
+
+    rng = random.Random(random_seed)
+    reservoir: dict[str, list[PyteomicsSpectrum]] = {}
+    counts: dict[str, int] = {}
+
+    for spectrum in iter_spectra(spectra, desc="Streaming spectra"):
+        seq = spectrum["params"]["seq"]
+        count = counts.get(seq, 0) + 1
+        counts[seq] = count
+        if count <= k:
+            reservoir.setdefault(seq, []).append(spectrum)
+        else:
+            j = rng.randint(0, count - 1)
+            if j < k:
+                reservoir[seq][j] = spectrum
+
+    result = list(itertools.chain.from_iterable(reservoir.values()))
+    logging.info(
+        "Retained %d spectra from %d unique peptides", len(result), len(reservoir)
+    )
+    write_spectra(result, outfile)
+    return result
+
+
+def downsample_spectra(
+    input_file: PathLike,
+    output_file: PathLike,
+    downsample_type: str = "number",
+    downsample_rate: float = 100,
+    random_seed: int = 42,
+) -> None:
+    """
+    Downsample an MGF file to a target number or proportion of spectra.
+
+    Makes two streaming passes: the first counts total spectra, the second
+    streams with an adaptive acceptance probability (needed/remaining) that
+    guarantees exactly k spectra are written.
+
+    Parameters
+    ----------
+    input_file : PathLike
+        Path to the input MGF file.
+    output_file : PathLike
+        Path for the downsampled output MGF file.  Must differ from
+        *input_file*.
+    downsample_type : str, default ``"number"``
+        One of ``"number"`` (retain exactly *downsample_rate* spectra) or
+        ``"proportion"`` (retain exactly ``round(total × downsample_rate)``).
+    downsample_rate : float, default 100
+        Target rate.  Positive integer for ``"number"``; in ``(0, 1]`` for
+        ``"proportion"``.
+    random_seed : int, default 42
+        Seed for the random number generator.
+    """
+    configure_logging(pathlib.Path(output_file).with_suffix(".log"))
+
+    if pathlib.Path(input_file).resolve() == pathlib.Path(output_file).resolve():
+        raise ValueError(
+            "input_file and output_file must be different paths; "
+            "overwriting the input in-place is not supported."
+        )
+
+    if downsample_type not in _VALID_DOWNSAMPLE_TYPES:
+        raise ValueError(
+            f"--downsample-type must be one of {sorted(_VALID_DOWNSAMPLE_TYPES)}, "
+            f"got {downsample_type!r}."
+        )
+
+    if downsample_type == "number":
+        if (
+            not np.isfinite(downsample_rate)
+            or downsample_rate != int(downsample_rate)
+            or int(downsample_rate) < 1
+        ):
+            raise ValueError(
+                "--downsample-rate must be a positive integer when "
+                f"--downsample-type is 'number', got {downsample_rate!r}."
+            )
+    else:
+        if not (0 < downsample_rate <= 1):
+            raise ValueError(
+                "--downsample-rate must be in (0, 1] when "
+                f"--downsample-type is '{downsample_type}', "
+                f"got {downsample_rate!r}."
+            )
+
+    rng = random.Random(random_seed)
+
+    # First pass: count total spectra.
+    with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
+        n = sum(
+            1 for _ in tqdm.tqdm(reader, desc="Counting spectra", unit="spectrum")
+        )
+
+    if downsample_type == "number":
+        k = min(int(downsample_rate), n)
+    else:
+        k = min(round(n * downsample_rate), n)
+
+    pct = k / n if n > 0 else 0.0
+    logging.info("Targeting %d of %d spectra (%.1f%%)", k, n, 100 * pct)
+
+    # Second pass: stream with adaptive acceptance probability.
+    needed = k
+    remaining = n
+
+    def _filtered():
+        nonlocal needed, remaining
+        with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
+            for spectrum in tqdm.tqdm(
+                reader, desc="Streaming spectra", unit="spectrum"
+            ):
+                if needed > 0 and rng.random() < needed / remaining:
+                    needed -= 1
+                    yield spectrum
+                remaining -= 1
+
+    pyteomics.mgf.write(_filtered(), output=str(output_file))
+    logging.info("Done writing %s", output_file)
+
+
 COMMANDS: Commands = {
     "pipeline": pipeline,
     "shuffle": shuffle,
     "downsample": downsample,
+    "spectra-per-peptide": spectra_per_peptide,
+    "downsample-spectra": downsample_spectra,
     "purge-redundant": purge_redundant,
 }
 

--- a/tests/test_mgfutils.py
+++ b/tests/test_mgfutils.py
@@ -1,13 +1,17 @@
 import numpy as np
 import pytest
 
+import pyteomics.mgf
+
 from casanovoutils.mgfutils import (
     downsample,
+    downsample_spectra,
     get_pep_dict_mgf,
     iter_spectra,
     pipeline,
     purge_redundant,
     shuffle,
+    spectra_per_peptide,
     write_spectra,
 )
 
@@ -257,3 +261,144 @@ def test_pipeline_writes_file(tmp_path):
     outfile = tmp_path / "out.mgf"
     pipeline(spectra, outfile=outfile, do_shuffle=False)
     assert outfile.exists()
+
+
+# ---------------------------------------------------------------------------
+# spectra_per_peptide
+# ---------------------------------------------------------------------------
+
+
+def test_spp_k1_limits_to_one_per_peptide():
+    spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(5)] + [
+        make_spectrum("BBB", [float(i)], [1.0]) for i in range(3)
+    ]
+    result = spectra_per_peptide(spectra, k=1)
+    seqs = [s["params"]["seq"] for s in result]
+    assert seqs.count("AAA") == 1
+    assert seqs.count("BBB") == 1
+
+
+def test_spp_k_greater_than_max_keeps_all():
+    spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(3)] + [
+        make_spectrum("BBB", [float(i)], [1.0]) for i in range(2)
+    ]
+    result = spectra_per_peptide(spectra, k=100)
+    assert len(result) == 5
+
+
+def test_spp_k_limits_per_peptide():
+    spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(5)] + [
+        make_spectrum("BBB", [float(i)], [1.0]) for i in range(4)
+    ]
+    result = spectra_per_peptide(spectra, k=2)
+    seqs = [s["params"]["seq"] for s in result]
+    assert seqs.count("AAA") == 2
+    assert seqs.count("BBB") == 2
+
+
+def test_spp_reproducible():
+    spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(10)] + [
+        make_spectrum("BBB", [float(i)], [1.0]) for i in range(10)
+    ]
+    r1 = spectra_per_peptide(list(spectra), k=3, random_seed=123)
+    r2 = spectra_per_peptide(list(spectra), k=3, random_seed=123)
+    assert [s["m/z array"][0] for s in r1] == [s["m/z array"][0] for s in r2]
+
+
+def test_spp_different_seeds_differ():
+    spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(20)]
+    r1 = spectra_per_peptide(list(spectra), k=5, random_seed=1)
+    r2 = spectra_per_peptide(list(spectra), k=5, random_seed=99)
+    assert [s["m/z array"][0] for s in r1] != [s["m/z array"][0] for s in r2]
+
+
+def test_spp_accepts_generator():
+    def _gen():
+        for i in range(3):
+            yield make_spectrum("AAA", [float(i)], [1.0])
+
+    result = spectra_per_peptide(_gen(), k=1)
+    assert len(result) == 1
+    assert result[0]["params"]["seq"] == "AAA"
+
+
+# ---------------------------------------------------------------------------
+# downsample_spectra
+# ---------------------------------------------------------------------------
+
+
+def _write_mgf_file(path, spectra):
+    pyteomics.mgf.write(spectra, output=str(path))
+    return path
+
+
+def _count_mgf(path):
+    with pyteomics.mgf.read(str(path), use_index=False) as r:
+        return sum(1 for _ in r)
+
+
+def test_ds_number_exact_count(tmp_path):
+    inp = _write_mgf_file(
+        tmp_path / "in.mgf",
+        [make_spectrum("P", [float(i)], [1.0]) for i in range(20)],
+    )
+    out = tmp_path / "out.mgf"
+    downsample_spectra(inp, out, downsample_type="number", downsample_rate=5)
+    assert _count_mgf(out) == 5
+
+
+def test_ds_number_larger_than_total_keeps_all(tmp_path):
+    inp = _write_mgf_file(
+        tmp_path / "in.mgf",
+        [make_spectrum("P", [float(i)], [1.0]) for i in range(10)],
+    )
+    out = tmp_path / "out.mgf"
+    downsample_spectra(inp, out, downsample_type="number", downsample_rate=100)
+    assert _count_mgf(out) == 10
+
+
+def test_ds_proportion_exact_count(tmp_path):
+    inp = _write_mgf_file(
+        tmp_path / "in.mgf",
+        [make_spectrum("P", [float(i)], [1.0]) for i in range(20)],
+    )
+    out = tmp_path / "out.mgf"
+    downsample_spectra(inp, out, downsample_type="proportion", downsample_rate=0.5)
+    assert _count_mgf(out) == 10
+
+
+def test_ds_reproducible(tmp_path):
+    inp = _write_mgf_file(
+        tmp_path / "in.mgf",
+        [make_spectrum("P", [float(i)], [1.0]) for i in range(50)],
+    )
+    out1 = tmp_path / "out1.mgf"
+    out2 = tmp_path / "out2.mgf"
+    downsample_spectra(inp, out1, downsample_type="number", downsample_rate=20, random_seed=7)
+    downsample_spectra(inp, out2, downsample_type="number", downsample_rate=20, random_seed=7)
+    with pyteomics.mgf.read(str(out1), use_index=False) as r1:
+        titles1 = [s["params"].get("title") for s in r1]
+    with pyteomics.mgf.read(str(out2), use_index=False) as r2:
+        titles2 = [s["params"].get("title") for s in r2]
+    assert titles1 == titles2
+
+
+def test_ds_same_path_raises(tmp_path):
+    inp = _write_mgf_file(
+        tmp_path / "in.mgf",
+        [make_spectrum("P", [1.0], [1.0])],
+    )
+    with pytest.raises(ValueError, match="different paths"):
+        downsample_spectra(inp, inp)
+
+
+def test_ds_invalid_type_raises(tmp_path):
+    inp = _write_mgf_file(tmp_path / "in.mgf", [make_spectrum("P", [1.0], [1.0])])
+    with pytest.raises(ValueError, match="downsample-type"):
+        downsample_spectra(inp, tmp_path / "out.mgf", downsample_type="bad")
+
+
+def test_ds_proportion_out_of_range_raises(tmp_path):
+    inp = _write_mgf_file(tmp_path / "in.mgf", [make_spectrum("P", [1.0], [1.0])])
+    with pytest.raises(ValueError, match=r"\(0, 1\]"):
+        downsample_spectra(inp, tmp_path / "out.mgf", downsample_type="proportion", downsample_rate=1.5)


### PR DESCRIPTION
Closes #23.

## Summary
- **`spectra-per-peptide`**: samples up to k spectra per peptide via single-pass reservoir sampling. O(unique peptides × k) memory. Exposed as `casanovoutils mgfutils spectra-per-peptide`.
- **`downsample-spectra`**: two-pass streaming approach — pass 1 counts spectra, pass 2 streams with an adaptive acceptance probability (`needed/remaining`) that guarantees exactly k outputs. Exposed as `casanovoutils mgfutils downsample-spectra`.

Both are added to `mgfutils.COMMANDS` and picked up automatically by the CLI in `main.py`. No `pyproject.toml` changes needed.

## Test plan
- [ ] `python -m pytest tests/test_mgfutils.py`
- [ ] `casanovoutils mgfutils <file.mgf> spectra-per-peptide --outfile=out.mgf`
- [ ] `casanovoutils mgfutils downsample-spectra <file.mgf> out.mgf --downsample_type=proportion --downsample_rate=0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `spectra-per-peptide` command for sampling up to k spectra per peptide sequence
  * Added `downsample-spectra` command for downsampling spectra to a target count or proportion

* **Tests**
  * Added comprehensive test coverage for the new spectra processing commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->