### PR TITLE
Set Minimum Python Version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 authors = [
     { email = "gwenneth.straub@gmail.com" }
 ]
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 dependencies = [
     "depthcharge-ms>=0.4.9",
     "fire>=0.7.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Python version compatibility by reducing the minimum required version to 3.10, enabling the project to run on a broader range of Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->