### PR TITLE
Add --precursor and --ignore-mods flags to spectra-per-peptide

### DIFF
--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -30,6 +30,7 @@ SpectraInput = PathLike | Iterable[PathLike] | Iterable[PyteomicsSpectrum]
 def iter_spectra(
     spectra: SpectraInput,
     desc: Optional[str] = None,
+    miniters: int = 1,
 ) -> Iterable[PyteomicsSpectrum]:
     """
     Normalize various spectrum input types to an iterable of PyteomicsSpectrum.
@@ -44,6 +45,8 @@ def iter_spectra(
     desc : str, optional
         Description for the tqdm progress bar. If ``None``, no progress bar
         is shown.
+    miniters : int, default=1
+        Minimum number of iterations between progress bar updates.
 
     Yields
     ------
@@ -68,7 +71,7 @@ def iter_spectra(
             raw = itertools.chain([first], it)
 
     if desc is not None:
-        raw = tqdm.tqdm(raw, desc=desc, unit="psm")
+        raw = tqdm.tqdm(raw, desc=desc, unit="psm", miniters=miniters)
 
     yield from raw
 
@@ -431,7 +434,7 @@ def spectra_per_peptide(
     reservoir: dict = {}
     counts: dict = {}
 
-    for spectrum in iter_spectra(spectra, desc="Streaming spectra"):
+    for spectrum in iter_spectra(spectra, desc="Streaming spectra", miniters=100_000):
         key = _group_key(spectrum, precursor=precursor, ignore_mods=ignore_mods)
         count = counts.get(key, 0) + 1
         counts[key] = count

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -12,6 +12,7 @@ import logging
 import os
 import pathlib
 import random
+import re
 from os import PathLike
 from typing import Iterable, Optional
 
@@ -345,20 +346,45 @@ def pipeline(
 _VALID_DOWNSAMPLE_TYPES = frozenset({"number", "proportion"})
 
 
+def _group_key(spectrum, precursor=False, ignore_mods=False):
+    """Return the grouping key for reservoir sampling.
+
+    Parameters
+    ----------
+    spectrum : PyteomicsSpectrum
+        A single spectrum dict.
+    precursor : bool
+        If True, include the charge state in the key so that the same peptide
+        in different charge states is treated as distinct groups.
+    ignore_mods : bool
+        If True, strip ProForma bracketed modification annotations from the
+        sequence before forming the key.
+    """
+    seq = spectrum["params"]["seq"]
+    if ignore_mods:
+        seq = re.sub(r"\[.*?\]", "", seq).strip("-")
+    if precursor:
+        charge = spectrum["params"].get("charge", "")
+        return (seq, charge)
+    return seq
+
+
 def spectra_per_peptide(
     spectra: SpectraInput,
     outfile: Optional[PathLike] = None,
     k: int = 1,
+    precursor: bool = False,
+    ignore_mods: bool = False,
     random_seed: int = 42,
 ) -> list[PyteomicsSpectrum]:
     """
     Sample up to k spectra per peptide using reservoir sampling.
 
     Makes a single streaming pass through *spectra*, maintaining a reservoir
-    of size k per unique peptide sequence.  For the j-th occurrence of a
-    peptide: if j <= k, add unconditionally; if j > k, replace a uniformly
-    random reservoir slot with probability k/j.  Memory usage is
-    O(unique peptides × k) rather than O(total spectra).
+    of size k per unique group.  For the j-th occurrence of a group: if
+    j <= k, add unconditionally; if j > k, replace a uniformly random
+    reservoir slot with probability k/j.  Memory usage is
+    O(unique groups × k) rather than O(total spectra).
 
     Parameters
     ----------
@@ -367,40 +393,55 @@ def spectra_per_peptide(
     outfile : PathLike, optional
         If provided, write the sampled spectra to this MGF file path.
     k : int, default=1
-        Maximum number of spectra to retain per peptide sequence.
+        Maximum number of spectra to retain per group.
+    precursor : bool, default=False
+        If True, group by peptide sequence *and* charge state, so that the
+        same peptide observed in different charge states is treated as
+        separate groups.
+    ignore_mods : bool, default=False
+        If True, strip ProForma bracketed modification annotations (e.g.
+        ``[Acetyl]``, ``[Carbamidomethyl]``) from the sequence before
+        grouping, so modified and unmodified forms of the same peptide are
+        counted together.
     random_seed : int, default=42
         Seed for the local random number generator.
 
     Returns
     -------
     list[PyteomicsSpectrum]
-        Sampled spectra, grouped by peptide in first-seen order.
+        Sampled spectra, grouped by key in first-seen order.
     """
     if not isinstance(k, int) or k < 1:
         raise ValueError(f"--k must be a positive integer, got {k!r}.")
     configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
     logging.info(
-        "Sampling up to k=%d spectra per peptide (random_seed=%d)", k, random_seed
+        "Sampling up to k=%d spectra per %s (precursor=%s, ignore_mods=%s, "
+        "random_seed=%d)",
+        k,
+        "precursor" if precursor else "peptide",
+        precursor,
+        ignore_mods,
+        random_seed,
     )
 
     rng = random.Random(random_seed)
-    reservoir: dict[str, list[PyteomicsSpectrum]] = {}
-    counts: dict[str, int] = {}
+    reservoir: dict = {}
+    counts: dict = {}
 
     for spectrum in iter_spectra(spectra, desc="Streaming spectra"):
-        seq = spectrum["params"]["seq"]
-        count = counts.get(seq, 0) + 1
-        counts[seq] = count
+        key = _group_key(spectrum, precursor=precursor, ignore_mods=ignore_mods)
+        count = counts.get(key, 0) + 1
+        counts[key] = count
         if count <= k:
-            reservoir.setdefault(seq, []).append(spectrum)
+            reservoir.setdefault(key, []).append(spectrum)
         else:
             j = rng.randint(0, count - 1)
             if j < k:
-                reservoir[seq][j] = spectrum
+                reservoir[key][j] = spectrum
 
     result = list(itertools.chain.from_iterable(reservoir.values()))
     logging.info(
-        "Retained %d spectra from %d unique peptides", len(result), len(reservoir)
+        "Retained %d spectra from %d unique groups", len(result), len(reservoir)
     )
     write_spectra(result, outfile)
     return result

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -365,6 +365,9 @@ def _group_key(spectrum, precursor=False, ignore_mods=False):
         seq = re.sub(r"\[.*?\]", "", seq).strip("-")
     if precursor:
         charge = spectrum["params"].get("charge", "")
+        # pyteomics returns ChargeList (a list subclass) for the charge field,
+        # which is unhashable. Convert to a canonical string for use as a key.
+        charge = str(charge)
         return (seq, charge)
     return seq
 
@@ -384,7 +387,7 @@ def spectra_per_peptide(
     of size k per unique group.  For the j-th occurrence of a group: if
     j <= k, add unconditionally; if j > k, replace a uniformly random
     reservoir slot with probability k/j.  Memory usage is
-    O(unique groups × k) rather than O(total spectra).
+    O(unique groups x k) rather than O(total spectra).
 
     Parameters
     ----------
@@ -553,7 +556,7 @@ COMMANDS: Commands = {
 
 
 def main() -> None:
-    fire.Fire(COMMANDS)
+    fire.Fire(COMMANDS, serialize=lambda _: "")
 
 
 if __name__ == "__main__":

--- a/tests/test_mgfutils.py
+++ b/tests/test_mgfutils.py
@@ -359,6 +359,15 @@ def test_spp_precursor_false_merges_charge_states():
     assert len(result) == 2
 
 
+def test_spp_precursor_list_charge_values():
+    # pyteomics parses CHARGE fields as ChargeList (a list subclass, unhashable)
+    spectra = [
+        make_spectrum_with_charge("AAA", [2], [float(i)], [1.0]) for i in range(3)
+    ] + [make_spectrum_with_charge("AAA", [3], [float(i)], [1.0]) for i in range(3)]
+    result = spectra_per_peptide(spectra, k=1, precursor=True)
+    assert len(result) == 2
+
+
 def test_spp_precursor_no_charge_field_does_not_raise():
     spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(3)]
     result = spectra_per_peptide(spectra, k=1, precursor=True)

--- a/tests/test_mgfutils.py
+++ b/tests/test_mgfutils.py
@@ -330,6 +330,91 @@ def test_spp_invalid_k_raises():
         spectra_per_peptide(spectra, k=-1)
 
 
+def make_spectrum_with_charge(seq, charge, mz, intensity):
+    s = make_spectrum(seq, mz, intensity)
+    s["params"]["charge"] = charge
+    return s
+
+
+# ---------------------------------------------------------------------------
+# spectra_per_peptide --precursor
+# ---------------------------------------------------------------------------
+
+
+def test_spp_precursor_separates_charge_states():
+    spectra = [
+        make_spectrum_with_charge("AAA", "2+", [float(i)], [1.0]) for i in range(4)
+    ] + [make_spectrum_with_charge("AAA", "3+", [float(i)], [1.0]) for i in range(4)]
+    result = spectra_per_peptide(spectra, k=2, precursor=True)
+    charges = [s["params"]["charge"] for s in result]
+    assert charges.count("2+") == 2
+    assert charges.count("3+") == 2
+
+
+def test_spp_precursor_false_merges_charge_states():
+    spectra = [
+        make_spectrum_with_charge("AAA", "2+", [float(i)], [1.0]) for i in range(4)
+    ] + [make_spectrum_with_charge("AAA", "3+", [float(i)], [1.0]) for i in range(4)]
+    result = spectra_per_peptide(spectra, k=2, precursor=False)
+    assert len(result) == 2
+
+
+def test_spp_precursor_no_charge_field_does_not_raise():
+    spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(3)]
+    result = spectra_per_peptide(spectra, k=1, precursor=True)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# spectra_per_peptide --ignore-mods
+# ---------------------------------------------------------------------------
+
+
+def test_spp_ignore_mods_merges_modified_forms():
+    spectra = [make_spectrum("[Acetyl]-AAA", [float(i)], [1.0]) for i in range(4)] + [
+        make_spectrum("AAA", [float(i)], [1.0]) for i in range(4)
+    ]
+    result = spectra_per_peptide(spectra, k=2, ignore_mods=True)
+    assert len(result) == 2
+
+
+def test_spp_ignore_mods_false_keeps_modified_separate():
+    spectra = [make_spectrum("[Acetyl]-AAA", [float(i)], [1.0]) for i in range(4)] + [
+        make_spectrum("AAA", [float(i)], [1.0]) for i in range(4)
+    ]
+    result = spectra_per_peptide(spectra, k=2, ignore_mods=False)
+    assert len(result) == 4
+
+
+def test_spp_ignore_mods_inline_mod():
+    spectra = [
+        make_spectrum("AAC[Carbamidomethyl]K", [float(i)], [1.0]) for i in range(3)
+    ] + [make_spectrum("AACK", [float(i)], [1.0]) for i in range(3)]
+    result = spectra_per_peptide(spectra, k=1, ignore_mods=True)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# spectra_per_peptide --precursor + --ignore-mods
+# ---------------------------------------------------------------------------
+
+
+def test_spp_precursor_and_ignore_mods_combined():
+    spectra = (
+        [
+            make_spectrum_with_charge("[Acetyl]-AAA", "2+", [float(i)], [1.0])
+            for i in range(3)
+        ]
+        + [make_spectrum_with_charge("AAA", "2+", [float(i)], [1.0]) for i in range(3)]
+        + [make_spectrum_with_charge("AAA", "3+", [float(i)], [1.0]) for i in range(3)]
+    )
+    result = spectra_per_peptide(spectra, k=1, precursor=True, ignore_mods=True)
+    charges = [s["params"]["charge"] for s in result]
+    assert len(result) == 2
+    assert charges.count("2+") == 1
+    assert charges.count("3+") == 1
+
+
 # ---------------------------------------------------------------------------
 # downsample_spectra
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `--precursor` flag to group spectra by peptide sequence **and** charge state, so the same peptide in different charge states is treated as distinct groups
- Adds `--ignore-mods` flag to strip ProForma bracketed modification annotations (e.g. `[Acetyl]`, `[Carbamidomethyl]`) before grouping, so modified and unmodified forms of the same peptide are counted together
- Introduces a `_group_key()` helper that centralizes grouping logic; the two flags are independent and can be combined
- Suppresses Fire serialization of return values (`serialize=lambda _: ""`) to avoid printing large spectrum lists to stdout

## Test plan

- [ ] `--precursor` separates spectra by charge state
- [ ] `--precursor=False` (default) merges charge states into one group
- [ ] `--precursor` with no charge field in params does not raise
- [ ] `--ignore-mods` merges N-terminal (`[Acetyl]-`) modified and unmodified forms
- [ ] `--ignore-mods` merges inline (`[Carbamidomethyl]`) modified and unmodified forms
- [ ] `--ignore-mods=False` (default) keeps modified forms separate
- [ ] `--precursor` and `--ignore-mods` combined work correctly
- [ ] All 50 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spectrum grouping now supports charge-state separation during sampling operations.
  * Peptide sequence matching can now optionally ignore sequence modifications when grouping.
  * Both features can be used independently or together for flexible data processing strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->