### PR TITLE
Speed up shuffle with raw text I/O

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,9 @@
   preventing duplicate handler registration when functions are composed.
 
 ### Changed
-
+- `casanovoutils mgfutils shuffle` was sped up with raw text IO. When the input
+  is file paths, a raw text IO fast path is used and otherwise the pyteomics
+  serialize method is used.
 - All CLI entry points consolidated into a single `casanovoutils` command with
   nested subcommands (`mgf`, `denovo`, `dump-residues`). The previous separate
   entry points (`graph-prec-cov`, `downsample-ms`, `mgf-utils`,

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -100,6 +100,8 @@ Reservoir-sample up to `k` spectra per peptide in a single streaming pass.
 | `spectra` | path | required | Input MGF file path |
 | `--k` | int | `1` | Maximum spectra per peptide |
 | `--outfile` | path | `None` | Output MGF file path |
+| `--precursor` | bool | `False` | Group by peptide sequence *and* charge state (same peptide in different charge states treated as separate groups) |
+| `--ignore_mods` | bool | `False` | Strip ProForma bracketed modification annotations before grouping (modified and unmodified forms counted together) |
 | `--random_seed` | int | `42` | Random seed for reproducibility |
 
 **Example:**

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -60,8 +60,8 @@ its enabling parameter is omitted.
 **Examples:**
 
 ```bash
-# Shuffle only
-casanovoutils mgfutils pipeline input.mgf --outfile out.mgf --nodo_shuffle False
+# Shuffle only (default; no extra flags needed)
+casanovoutils mgfutils pipeline input.mgf --outfile out.mgf
 
 # Cap at 2 spectra per peptide, no shuffle
 casanovoutils mgfutils pipeline input.mgf --outfile out.mgf --nodo_shuffle --downsample_k 2

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -30,6 +30,7 @@ SpectraInput = PathLike | Iterable[PathLike] | Iterable[PyteomicsSpectrum]
 def iter_spectra(
     spectra: SpectraInput,
     desc: Optional[str] = None,
+    miniters: int = 1,
 ) -> Iterable[PyteomicsSpectrum]:
     """
     Normalize various spectrum input types to an iterable of PyteomicsSpectrum.
@@ -44,6 +45,8 @@ def iter_spectra(
     desc : str, optional
         Description for the tqdm progress bar. If ``None``, no progress bar
         is shown.
+    miniters : int, default=1
+        Minimum number of iterations between progress bar updates.
 
     Yields
     ------
@@ -68,7 +71,7 @@ def iter_spectra(
             raw = itertools.chain([first], it)
 
     if desc is not None:
-        raw = tqdm.tqdm(raw, desc=desc, unit="psm")
+        raw = tqdm.tqdm(raw, desc=desc, unit="psm", miniters=miniters)
 
     yield from raw
 
@@ -431,7 +434,7 @@ def spectra_per_peptide(
     reservoir: dict = {}
     counts: dict = {}
 
-    for spectrum in iter_spectra(spectra, desc="Streaming spectra"):
+    for spectrum in iter_spectra(spectra, desc="Streaming spectra", miniters=100_000):
         key = _group_key(spectrum, precursor=precursor, ignore_mods=ignore_mods)
         count = counts.get(key, 0) + 1
         counts[key] = count

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -247,7 +247,13 @@ def purge_redundant(
 
 
 def _iter_raw_blocks(paths: Iterable[PathLike]) -> Iterable[str]:
-    """Yield raw MGF text blocks from one or more file paths without parsing."""
+    """Yield raw MGF text blocks from one or more file paths without parsing.
+
+    Lines before the first ``BEGIN IONS`` (global MGF header parameters) are
+    not preserved. This is intentional: global headers are uncommon in practice
+    and the fast path is not a drop-in replacement for the pyteomics round-trip
+    in their presence.
+    """
     for path in paths:
         with open(path) as f:
             block: list[str] = []
@@ -305,6 +311,7 @@ def shuffle(
             try:
                 first = next(it)
             except StopIteration:
+                open(outfile, "w").close()
                 return []
             if isinstance(first, (str, os.PathLike)):
                 paths = list(itertools.chain([first], it))

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -12,6 +12,7 @@ import logging
 import os
 import pathlib
 import random
+import re
 from os import PathLike
 from typing import Iterable, Optional
 
@@ -345,20 +346,45 @@ def pipeline(
 _VALID_DOWNSAMPLE_TYPES = frozenset({"number", "proportion"})
 
 
+def _group_key(spectrum, precursor=False, ignore_mods=False):
+    """Return the grouping key for reservoir sampling.
+
+    Parameters
+    ----------
+    spectrum : PyteomicsSpectrum
+        A single spectrum dict.
+    precursor : bool
+        If True, include the charge state in the key so that the same peptide
+        in different charge states is treated as distinct groups.
+    ignore_mods : bool
+        If True, strip ProForma bracketed modification annotations from the
+        sequence before forming the key.
+    """
+    seq = spectrum["params"]["seq"]
+    if ignore_mods:
+        seq = re.sub(r"\[.*?\]", "", seq).strip("-")
+    if precursor:
+        charge = spectrum["params"].get("charge", "")
+        return (seq, charge)
+    return seq
+
+
 def spectra_per_peptide(
     spectra: SpectraInput,
     outfile: Optional[PathLike] = None,
     k: int = 1,
+    precursor: bool = False,
+    ignore_mods: bool = False,
     random_seed: int = 42,
 ) -> list[PyteomicsSpectrum]:
     """
     Sample up to k spectra per peptide using reservoir sampling.
 
     Makes a single streaming pass through *spectra*, maintaining a reservoir
-    of size k per unique peptide sequence.  For the j-th occurrence of a
-    peptide: if j <= k, add unconditionally; if j > k, replace a uniformly
-    random reservoir slot with probability k/j.  Memory usage is
-    O(unique peptides × k) rather than O(total spectra).
+    of size k per unique group.  For the j-th occurrence of a group: if
+    j <= k, add unconditionally; if j > k, replace a uniformly random
+    reservoir slot with probability k/j.  Memory usage is
+    O(unique groups × k) rather than O(total spectra).
 
     Parameters
     ----------
@@ -367,40 +393,55 @@ def spectra_per_peptide(
     outfile : PathLike, optional
         If provided, write the sampled spectra to this MGF file path.
     k : int, default=1
-        Maximum number of spectra to retain per peptide sequence.
+        Maximum number of spectra to retain per group.
+    precursor : bool, default=False
+        If True, group by peptide sequence *and* charge state, so that the
+        same peptide observed in different charge states is treated as
+        separate groups.
+    ignore_mods : bool, default=False
+        If True, strip ProForma bracketed modification annotations (e.g.
+        ``[Acetyl]``, ``[Carbamidomethyl]``) from the sequence before
+        grouping, so modified and unmodified forms of the same peptide are
+        counted together.
     random_seed : int, default=42
         Seed for the local random number generator.
 
     Returns
     -------
     list[PyteomicsSpectrum]
-        Sampled spectra, grouped by peptide in first-seen order.
+        Sampled spectra, grouped by key in first-seen order.
     """
     if not isinstance(k, int) or k < 1:
         raise ValueError(f"--k must be a positive integer, got {k!r}.")
     configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
     logging.info(
-        "Sampling up to k=%d spectra per peptide (random_seed=%d)", k, random_seed
+        "Sampling up to k=%d spectra per %s (precursor=%s, ignore_mods=%s, "
+        "random_seed=%d)",
+        k,
+        "precursor" if precursor else "peptide",
+        precursor,
+        ignore_mods,
+        random_seed,
     )
 
     rng = random.Random(random_seed)
-    reservoir: dict[str, list[PyteomicsSpectrum]] = {}
-    counts: dict[str, int] = {}
+    reservoir: dict = {}
+    counts: dict = {}
 
     for spectrum in iter_spectra(spectra, desc="Streaming spectra"):
-        seq = spectrum["params"]["seq"]
-        count = counts.get(seq, 0) + 1
-        counts[seq] = count
+        key = _group_key(spectrum, precursor=precursor, ignore_mods=ignore_mods)
+        count = counts.get(key, 0) + 1
+        counts[key] = count
         if count <= k:
-            reservoir.setdefault(seq, []).append(spectrum)
+            reservoir.setdefault(key, []).append(spectrum)
         else:
             j = rng.randint(0, count - 1)
             if j < k:
-                reservoir[seq][j] = spectrum
+                reservoir[key][j] = spectrum
 
     result = list(itertools.chain.from_iterable(reservoir.values()))
     logging.info(
-        "Retained %d spectra from %d unique peptides", len(result), len(reservoir)
+        "Retained %d spectra from %d unique groups", len(result), len(reservoir)
     )
     write_spectra(result, outfile)
     return result

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -365,6 +365,9 @@ def _group_key(spectrum, precursor=False, ignore_mods=False):
         seq = re.sub(r"\[.*?\]", "", seq).strip("-")
     if precursor:
         charge = spectrum["params"].get("charge", "")
+        # pyteomics returns ChargeList (a list subclass) for the charge field,
+        # which is unhashable. Convert to a canonical string for use as a key.
+        charge = str(charge)
         return (seq, charge)
     return seq
 
@@ -384,7 +387,7 @@ def spectra_per_peptide(
     of size k per unique group.  For the j-th occurrence of a group: if
     j <= k, add unconditionally; if j > k, replace a uniformly random
     reservoir slot with probability k/j.  Memory usage is
-    O(unique groups × k) rather than O(total spectra).
+    O(unique groups x k) rather than O(total spectra).
 
     Parameters
     ----------
@@ -553,7 +556,7 @@ COMMANDS: Commands = {
 
 
 def main() -> None:
-    fire.Fire(COMMANDS)
+    fire.Fire(COMMANDS, serialize=lambda _: "")
 
 
 if __name__ == "__main__":

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -246,6 +246,22 @@ def purge_redundant(
     return spectra
 
 
+def _iter_raw_blocks(paths: Iterable[PathLike]) -> Iterable[str]:
+    """Yield raw MGF text blocks from one or more file paths without parsing."""
+    for path in paths:
+        with open(path) as f:
+            block: list[str] = []
+            for line in f:
+                if line.strip() == "BEGIN IONS":
+                    block = [line]
+                elif line.strip() == "END IONS":
+                    block.append(line)
+                    yield "".join(block)
+                    block = []
+                elif block:
+                    block.append(line)
+
+
 def shuffle(
     spectra: SpectraInput,
     outfile: Optional[PathLike] = None,
@@ -253,6 +269,11 @@ def shuffle(
 ) -> list[PyteomicsSpectrum]:
     """
     Read all spectra and return them in a shuffled order.
+
+    When *spectra* is a file path (or iterable of file paths) and *outfile* is
+    provided, a fast raw-text path is used: entries are shuffled as opaque
+    strings without parsing peaks, which is significantly faster than the
+    pyteomics parse/serialize round-trip.
 
     Parameters
     ----------
@@ -266,12 +287,41 @@ def shuffle(
     Returns
     -------
     list[PyteomicsSpectrum]
-        All spectra in shuffled order.
+        All spectra in shuffled order, or an empty list when the fast raw-text
+        path is used (output was written directly to *outfile*).
     """
     configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
 
     logging.info("Shuffling spectra (random_seed=%d)", random_seed)
     random.seed(random_seed)
+
+    # Fast path: avoid pyteomics parse/serialize when input is file path(s).
+    if outfile is not None:
+        if isinstance(spectra, (str, os.PathLike)):
+            paths: list[PathLike] = [spectra]
+            use_raw = True
+        else:
+            it = iter(spectra)
+            try:
+                first = next(it)
+            except StopIteration:
+                return []
+            if isinstance(first, (str, os.PathLike)):
+                paths = list(itertools.chain([first], it))
+                use_raw = True
+            else:
+                spectra = itertools.chain([first], it)
+                use_raw = False
+
+        if use_raw:
+            blocks = list(
+                tqdm.tqdm(_iter_raw_blocks(paths), desc="Reading spectra", unit="psm")
+            )
+            random.shuffle(blocks)
+            logging.info("Shuffled %d spectra", len(blocks))
+            with open(outfile, "w") as f:
+                f.writelines(tqdm.tqdm(blocks, desc=f"Writing {outfile}", unit="psm"))
+            return []
 
     result = list(iter_spectra(spectra, desc="Reading spectra"))
     random.shuffle(result)

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -255,7 +255,10 @@ def shuffle(
     When *spectra* is a file path (or iterable of file paths) and *outfile* is
     provided, a fast raw-text path is used: entries are shuffled as opaque
     strings without parsing peaks, which is significantly faster than the
-    pyteomics parse/serialize round-trip.
+    pyteomics parse/serialize round-trip.  Note that the fast path does not
+    preserve MGF global header parameters (lines before the first
+    ``BEGIN IONS``); use the slow path (pass parsed spectra) if your files
+    rely on global defaults.
 
     Parameters
     ----------

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -381,7 +381,9 @@ def pipeline(
             result = shuffle(result, random_seed=random_seed)
 
         if downsample_k is not None:
-            result = spectra_per_peptide(result, k=downsample_k, random_seed=random_seed)
+            result = spectra_per_peptide(
+                result, k=downsample_k, random_seed=random_seed
+            )
 
         if purge_epsilon is not None:
             result = purge_redundant(result, epsilon=purge_epsilon)

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -191,14 +191,20 @@ def purge_redundant(
     list[PyteomicsSpectrum]
         Spectra with redundant peaks removed and peaks sorted by m/z.
     """
-    configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
-    logging.info("Purging redundant peaks with epsilon=%g Da", epsilon)
-    spectra = iter_spectra(spectra, desc="Purging redundant peaks")
-    spectra = map(lambda s: remove_redundant_peaks(s, epsilon), spectra)
-    spectra = list(spectra)
-    write_spectra(spectra, outfile)
-
-    return spectra
+    file_handler = configure_logging(
+        pathlib.Path(outfile).with_suffix(".log") if outfile else None
+    )
+    try:
+        logging.info("Purging redundant peaks with epsilon=%g Da", epsilon)
+        spectra = iter_spectra(spectra, desc="Purging redundant peaks")
+        spectra = map(lambda s: remove_redundant_peaks(s, epsilon), spectra)
+        spectra = list(spectra)
+        write_spectra(spectra, outfile)
+        return spectra
+    finally:
+        if file_handler is not None:
+            logging.root.removeHandler(file_handler)
+            file_handler.close()
 
 
 def _iter_raw_blocks(paths: Iterable[PathLike]) -> Iterable[str]:
@@ -251,45 +257,55 @@ def shuffle(
         All spectra in shuffled order, or an empty list when the fast raw-text
         path is used (output was written directly to *outfile*).
     """
-    configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
+    file_handler = configure_logging(
+        pathlib.Path(outfile).with_suffix(".log") if outfile else None
+    )
+    try:
+        logging.info("Shuffling spectra (random_seed=%d)", random_seed)
+        random.seed(random_seed)
 
-    logging.info("Shuffling spectra (random_seed=%d)", random_seed)
-    random.seed(random_seed)
-
-    # Fast path: avoid pyteomics parse/serialize when input is file path(s).
-    if outfile is not None:
-        if isinstance(spectra, (str, os.PathLike)):
-            paths: list[PathLike] = [spectra]
-            use_raw = True
-        else:
-            it = iter(spectra)
-            try:
-                first = next(it)
-            except StopIteration:
-                open(outfile, "w").close()
-                return []
-            if isinstance(first, (str, os.PathLike)):
-                paths = list(itertools.chain([first], it))
+        # Fast path: avoid pyteomics parse/serialize when input is file path(s).
+        if outfile is not None:
+            if isinstance(spectra, (str, os.PathLike)):
+                paths: list[PathLike] = [spectra]
                 use_raw = True
             else:
-                spectra = itertools.chain([first], it)
-                use_raw = False
+                it = iter(spectra)
+                try:
+                    first = next(it)
+                except StopIteration:
+                    open(outfile, "w").close()
+                    return []
+                if isinstance(first, (str, os.PathLike)):
+                    paths = list(itertools.chain([first], it))
+                    use_raw = True
+                else:
+                    spectra = itertools.chain([first], it)
+                    use_raw = False
 
-        if use_raw:
-            blocks = list(
-                tqdm.tqdm(_iter_raw_blocks(paths), desc="Reading spectra", unit="psm")
-            )
-            random.shuffle(blocks)
-            logging.info("Shuffled %d spectra", len(blocks))
-            with open(outfile, "w") as f:
-                f.writelines(tqdm.tqdm(blocks, desc=f"Writing {outfile}", unit="psm"))
-            return []
+            if use_raw:
+                blocks = list(
+                    tqdm.tqdm(
+                        _iter_raw_blocks(paths), desc="Reading spectra", unit="psm"
+                    )
+                )
+                random.shuffle(blocks)
+                logging.info("Shuffled %d spectra", len(blocks))
+                with open(outfile, "w") as f:
+                    f.writelines(
+                        tqdm.tqdm(blocks, desc=f"Writing {outfile}", unit="psm")
+                    )
+                return []
 
-    result = list(iter_spectra(spectra, desc="Reading spectra"))
-    random.shuffle(result)
-    logging.info("Shuffled %d spectra", len(result))
-    write_spectra(result, outfile)
-    return result
+        result = list(iter_spectra(spectra, desc="Reading spectra"))
+        random.shuffle(result)
+        logging.info("Shuffled %d spectra", len(result))
+        write_spectra(result, outfile)
+        return result
+    finally:
+        if file_handler is not None:
+            logging.root.removeHandler(file_handler)
+            file_handler.close()
 
 
 def pipeline(
@@ -329,34 +345,40 @@ def pipeline(
     list[PyteomicsSpectrum]
         Processed spectra.
     """
-    configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
-
-    stages = []
-    if do_shuffle:
-        stages.append("shuffle")
-    if downsample_k is not None:
-        stages.append(f"spectra-per-peptide(k={downsample_k})")
-    if purge_epsilon is not None:
-        stages.append(f"purge-redundant(epsilon={purge_epsilon})")
-    logging.info(
-        "Running pipeline stages: %s", " -> ".join(stages) if stages else "none"
+    file_handler = configure_logging(
+        pathlib.Path(outfile).with_suffix(".log") if outfile else None
     )
+    try:
+        stages = []
+        if do_shuffle:
+            stages.append("shuffle")
+        if downsample_k is not None:
+            stages.append(f"spectra-per-peptide(k={downsample_k})")
+        if purge_epsilon is not None:
+            stages.append(f"purge-redundant(epsilon={purge_epsilon})")
+        logging.info(
+            "Running pipeline stages: %s", " -> ".join(stages) if stages else "none"
+        )
 
-    result: SpectraInput = spectra
+        result: SpectraInput = spectra
 
-    if do_shuffle:
-        result = shuffle(result, random_seed=random_seed)
+        if do_shuffle:
+            result = shuffle(result, random_seed=random_seed)
 
-    if downsample_k is not None:
-        result = spectra_per_peptide(result, k=downsample_k, random_seed=random_seed)
+        if downsample_k is not None:
+            result = spectra_per_peptide(result, k=downsample_k, random_seed=random_seed)
 
-    if purge_epsilon is not None:
-        result = purge_redundant(result, epsilon=purge_epsilon)
-    else:
-        result = list(iter_spectra(result))
+        if purge_epsilon is not None:
+            result = purge_redundant(result, epsilon=purge_epsilon)
+        else:
+            result = list(iter_spectra(result))
 
-    write_spectra(result, outfile)
-    return result
+        write_spectra(result, outfile)
+        return result
+    finally:
+        if file_handler is not None:
+            logging.root.removeHandler(file_handler)
+            file_handler.close()
 
 
 _VALID_DOWNSAMPLE_TYPES = frozenset({"number", "proportion"})
@@ -432,38 +454,47 @@ def spectra_per_peptide(
     """
     if not isinstance(k, int) or k < 1:
         raise ValueError(f"--k must be a positive integer, got {k!r}.")
-    configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
-    logging.info(
-        "Sampling up to k=%d spectra per %s (precursor=%s, ignore_mods=%s, "
-        "random_seed=%d)",
-        k,
-        "precursor" if precursor else "peptide",
-        precursor,
-        ignore_mods,
-        random_seed,
+    file_handler = configure_logging(
+        pathlib.Path(outfile).with_suffix(".log") if outfile else None
     )
+    try:
+        logging.info(
+            "Sampling up to k=%d spectra per %s (precursor=%s, ignore_mods=%s, "
+            "random_seed=%d)",
+            k,
+            "precursor" if precursor else "peptide",
+            precursor,
+            ignore_mods,
+            random_seed,
+        )
 
-    rng = random.Random(random_seed)
-    reservoir: dict = {}
-    counts: dict = {}
+        rng = random.Random(random_seed)
+        reservoir: dict = {}
+        counts: dict = {}
 
-    for spectrum in iter_spectra(spectra, desc="Streaming spectra", miniters=100_000):
-        key = _group_key(spectrum, precursor=precursor, ignore_mods=ignore_mods)
-        count = counts.get(key, 0) + 1
-        counts[key] = count
-        if count <= k:
-            reservoir.setdefault(key, []).append(spectrum)
-        else:
-            j = rng.randint(0, count - 1)
-            if j < k:
-                reservoir[key][j] = spectrum
+        for spectrum in iter_spectra(
+            spectra, desc="Streaming spectra", miniters=100_000
+        ):
+            key = _group_key(spectrum, precursor=precursor, ignore_mods=ignore_mods)
+            count = counts.get(key, 0) + 1
+            counts[key] = count
+            if count <= k:
+                reservoir.setdefault(key, []).append(spectrum)
+            else:
+                j = rng.randint(0, count - 1)
+                if j < k:
+                    reservoir[key][j] = spectrum
 
-    result = list(itertools.chain.from_iterable(reservoir.values()))
-    logging.info(
-        "Retained %d spectra from %d unique groups", len(result), len(reservoir)
-    )
-    write_spectra(result, outfile)
-    return result
+        result = list(itertools.chain.from_iterable(reservoir.values()))
+        logging.info(
+            "Retained %d spectra from %d unique groups", len(result), len(reservoir)
+        )
+        write_spectra(result, outfile)
+        return result
+    finally:
+        if file_handler is not None:
+            logging.root.removeHandler(file_handler)
+            file_handler.close()
 
 
 def downsample_spectra(
@@ -496,69 +527,75 @@ def downsample_spectra(
     random_seed : int, default 42
         Seed for the random number generator.
     """
-    configure_logging(pathlib.Path(output_file).with_suffix(".log"))
-
-    if pathlib.Path(input_file).resolve() == pathlib.Path(output_file).resolve():
-        raise ValueError(
-            "input_file and output_file must be different paths; "
-            "overwriting the input in-place is not supported."
-        )
-
-    if downsample_type not in _VALID_DOWNSAMPLE_TYPES:
-        raise ValueError(
-            f"--downsample_type must be one of {sorted(_VALID_DOWNSAMPLE_TYPES)}, "
-            f"got {downsample_type!r}."
-        )
-
-    if downsample_type == "number":
-        if (
-            not np.isfinite(downsample_rate)
-            or downsample_rate != int(downsample_rate)
-            or int(downsample_rate) < 1
-        ):
+    file_handler = configure_logging(pathlib.Path(output_file).with_suffix(".log"))
+    try:
+        if pathlib.Path(input_file).resolve() == pathlib.Path(output_file).resolve():
             raise ValueError(
-                "--downsample_rate must be a positive integer when "
-                f"--downsample_type is 'number', got {downsample_rate!r}."
-            )
-    else:
-        if not (0 < downsample_rate <= 1):
-            raise ValueError(
-                "--downsample_rate must be in (0, 1] when "
-                f"--downsample_type is '{downsample_type}', "
-                f"got {downsample_rate!r}."
+                "input_file and output_file must be different paths; "
+                "overwriting the input in-place is not supported."
             )
 
-    rng = random.Random(random_seed)
+        if downsample_type not in _VALID_DOWNSAMPLE_TYPES:
+            raise ValueError(
+                f"--downsample_type must be one of {sorted(_VALID_DOWNSAMPLE_TYPES)}, "
+                f"got {downsample_type!r}."
+            )
 
-    # First pass: count total spectra.
-    with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
-        n = sum(1 for _ in tqdm.tqdm(reader, desc="Counting spectra", unit="spectrum"))
-
-    if downsample_type == "number":
-        k = min(int(downsample_rate), n)
-    else:
-        k = min(round(n * downsample_rate), n)
-
-    pct = k / n if n > 0 else 0.0
-    logging.info("Targeting %d of %d spectra (%.1f%%)", k, n, 100 * pct)
-
-    # Second pass: stream with adaptive acceptance probability.
-    needed = k
-    remaining = n
-
-    def _filtered():
-        nonlocal needed, remaining
-        with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
-            for spectrum in tqdm.tqdm(
-                reader, desc="Streaming spectra", unit="spectrum"
+        if downsample_type == "number":
+            if (
+                not np.isfinite(downsample_rate)
+                or downsample_rate != int(downsample_rate)
+                or int(downsample_rate) < 1
             ):
-                if needed > 0 and rng.random() < needed / remaining:
-                    needed -= 1
-                    yield spectrum
-                remaining -= 1
+                raise ValueError(
+                    "--downsample_rate must be a positive integer when "
+                    f"--downsample_type is 'number', got {downsample_rate!r}."
+                )
+        else:
+            if not (0 < downsample_rate <= 1):
+                raise ValueError(
+                    "--downsample_rate must be in (0, 1] when "
+                    f"--downsample_type is '{downsample_type}', "
+                    f"got {downsample_rate!r}."
+                )
 
-    pyteomics.mgf.write(_filtered(), output=str(output_file))
-    logging.info("Done writing %s", output_file)
+        rng = random.Random(random_seed)
+
+        # First pass: count total spectra.
+        with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
+            n = sum(
+                1 for _ in tqdm.tqdm(reader, desc="Counting spectra", unit="spectrum")
+            )
+
+        if downsample_type == "number":
+            k = min(int(downsample_rate), n)
+        else:
+            k = min(round(n * downsample_rate), n)
+
+        pct = k / n if n > 0 else 0.0
+        logging.info("Targeting %d of %d spectra (%.1f%%)", k, n, 100 * pct)
+
+        # Second pass: stream with adaptive acceptance probability.
+        needed = k
+        remaining = n
+
+        def _filtered():
+            nonlocal needed, remaining
+            with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
+                for spectrum in tqdm.tqdm(
+                    reader, desc="Streaming spectra", unit="spectrum"
+                ):
+                    if needed > 0 and rng.random() < needed / remaining:
+                        needed -= 1
+                        yield spectrum
+                    remaining -= 1
+
+        pyteomics.mgf.write(_filtered(), output=str(output_file))
+        logging.info("Done writing %s", output_file)
+    finally:
+        if file_handler is not None:
+            logging.root.removeHandler(file_handler)
+            file_handler.close()
 
 
 COMMANDS: Commands = {

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -310,9 +310,12 @@ def shuffle(
                 random.shuffle(blocks)
                 logging.info("Shuffled %d spectra", len(blocks))
                 with open(outfile, "w") as f:
-                    f.writelines(
-                        tqdm.tqdm(blocks, desc=f"Writing {outfile}", unit="psm")
-                    )
+                    for block in tqdm.tqdm(
+                        blocks, desc=f"Writing {outfile}", unit="psm"
+                    ):
+                        f.write(block)
+                        if not block.endswith("\n"):
+                            f.write("\n")
                 return []
 
         result = list(iter_spectra(spectra, desc="Reading spectra"))

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -201,6 +201,22 @@ def purge_redundant(
     return spectra
 
 
+def _iter_raw_blocks(paths: Iterable[PathLike]) -> Iterable[str]:
+    """Yield raw MGF text blocks from one or more file paths without parsing."""
+    for path in paths:
+        with open(path) as f:
+            block: list[str] = []
+            for line in f:
+                if line.strip() == "BEGIN IONS":
+                    block = [line]
+                elif line.strip() == "END IONS":
+                    block.append(line)
+                    yield "".join(block)
+                    block = []
+                elif block:
+                    block.append(line)
+
+
 def shuffle(
     spectra: SpectraInput,
     outfile: Optional[PathLike] = None,
@@ -208,6 +224,11 @@ def shuffle(
 ) -> list[PyteomicsSpectrum]:
     """
     Read all spectra and return them in a shuffled order.
+
+    When *spectra* is a file path (or iterable of file paths) and *outfile* is
+    provided, a fast raw-text path is used: entries are shuffled as opaque
+    strings without parsing peaks, which is significantly faster than the
+    pyteomics parse/serialize round-trip.
 
     Parameters
     ----------
@@ -221,12 +242,41 @@ def shuffle(
     Returns
     -------
     list[PyteomicsSpectrum]
-        All spectra in shuffled order.
+        All spectra in shuffled order, or an empty list when the fast raw-text
+        path is used (output was written directly to *outfile*).
     """
     configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
 
     logging.info("Shuffling spectra (random_seed=%d)", random_seed)
     random.seed(random_seed)
+
+    # Fast path: avoid pyteomics parse/serialize when input is file path(s).
+    if outfile is not None:
+        if isinstance(spectra, (str, os.PathLike)):
+            paths: list[PathLike] = [spectra]
+            use_raw = True
+        else:
+            it = iter(spectra)
+            try:
+                first = next(it)
+            except StopIteration:
+                return []
+            if isinstance(first, (str, os.PathLike)):
+                paths = list(itertools.chain([first], it))
+                use_raw = True
+            else:
+                spectra = itertools.chain([first], it)
+                use_raw = False
+
+        if use_raw:
+            blocks = list(
+                tqdm.tqdm(_iter_raw_blocks(paths), desc="Reading spectra", unit="psm")
+            )
+            random.shuffle(blocks)
+            logging.info("Shuffled %d spectra", len(blocks))
+            with open(outfile, "w") as f:
+                f.writelines(tqdm.tqdm(blocks, desc=f"Writing {outfile}", unit="psm"))
+            return []
 
     result = list(iter_spectra(spectra, desc="Reading spectra"))
     random.shuffle(result)

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -214,12 +214,21 @@ def _iter_raw_blocks(paths: Iterable[PathLike]) -> Iterable[str]:
     not preserved. This is intentional: global headers are uncommon in practice
     and the fast path is not a drop-in replacement for the pyteomics round-trip
     in their presence.
+
+    Malformed entries (a ``BEGIN IONS`` that is never closed, or a second
+    ``BEGIN IONS`` before ``END IONS``) are logged as warnings and skipped.
     """
     for path in paths:
         with open(path) as f:
             block: list[str] = []
             for line in f:
                 if line.strip() == "BEGIN IONS":
+                    if block:
+                        logging.warning(
+                            "Malformed MGF in %s: new BEGIN IONS before END IONS"
+                            " — skipping incomplete block",
+                            path,
+                        )
                     block = [line]
                 elif line.strip() == "END IONS":
                     block.append(line)
@@ -227,6 +236,12 @@ def _iter_raw_blocks(paths: Iterable[PathLike]) -> Iterable[str]:
                     block = []
                 elif block:
                     block.append(line)
+            if block:
+                logging.warning(
+                    "Malformed MGF in %s: file ended without END IONS"
+                    " — skipping incomplete block",
+                    path,
+                )
 
 
 def shuffle(

--- a/src/casanovoutils/mgfutils.py
+++ b/src/casanovoutils/mgfutils.py
@@ -202,7 +202,13 @@ def purge_redundant(
 
 
 def _iter_raw_blocks(paths: Iterable[PathLike]) -> Iterable[str]:
-    """Yield raw MGF text blocks from one or more file paths without parsing."""
+    """Yield raw MGF text blocks from one or more file paths without parsing.
+
+    Lines before the first ``BEGIN IONS`` (global MGF header parameters) are
+    not preserved. This is intentional: global headers are uncommon in practice
+    and the fast path is not a drop-in replacement for the pyteomics round-trip
+    in their presence.
+    """
     for path in paths:
         with open(path) as f:
             block: list[str] = []
@@ -260,6 +266,7 @@ def shuffle(
             try:
                 first = next(it)
             except StopIteration:
+                open(outfile, "w").close()
                 return []
             if isinstance(first, (str, os.PathLike)):
                 paths = list(itertools.chain([first], it))

--- a/tests/test_mgfutils.py
+++ b/tests/test_mgfutils.py
@@ -212,6 +212,56 @@ def test_shuffle_writes_file(tmp_path):
     assert outfile.exists()
 
 
+def _write_mgf(path, sequences):
+    """Write a minimal MGF file with one entry per sequence."""
+    with open(path, "w") as f:
+        for seq in sequences:
+            f.write("BEGIN IONS\n")
+            f.write(f"SEQ={seq}\n")
+            f.write("100.0 1.0\n")
+            f.write("END IONS\n")
+
+
+def test_shuffle_fast_path_single_file(tmp_path):
+    mgf_in = tmp_path / "input.mgf"
+    mgf_out = tmp_path / "output.mgf"
+    sequences = ["PEPTIDE", "ANOTHER", "THIRD", "FOURTH", "FIFTH"]
+    _write_mgf(mgf_in, sequences)
+
+    result = shuffle(mgf_in, outfile=mgf_out, random_seed=42)
+
+    assert result == []
+    assert mgf_out.exists()
+    content = mgf_out.read_text()
+    for seq in sequences:
+        assert content.count(f"SEQ={seq}") == 1
+
+
+def test_shuffle_fast_path_multiple_files(tmp_path):
+    mgf1 = tmp_path / "input1.mgf"
+    mgf2 = tmp_path / "input2.mgf"
+    mgf_out = tmp_path / "output.mgf"
+    seqs1 = ["PEPTIDE", "ANOTHER"]
+    seqs2 = ["THIRD", "FOURTH"]
+    _write_mgf(mgf1, seqs1)
+    _write_mgf(mgf2, seqs2)
+
+    result = shuffle([mgf1, mgf2], outfile=mgf_out, random_seed=42)
+
+    assert result == []
+    assert mgf_out.exists()
+    content = mgf_out.read_text()
+    for seq in seqs1 + seqs2:
+        assert content.count(f"SEQ={seq}") == 1
+
+
+def test_shuffle_fast_path_empty_input(tmp_path):
+    mgf_out = tmp_path / "output.mgf"
+    result = shuffle(iter([]), outfile=mgf_out)
+    assert result == []
+    assert mgf_out.exists()
+
+
 # ---------------------------------------------------------------------------
 # pipeline
 # ---------------------------------------------------------------------------

--- a/tests/test_mgfutils.py
+++ b/tests/test_mgfutils.py
@@ -359,6 +359,15 @@ def test_spp_precursor_false_merges_charge_states():
     assert len(result) == 2
 
 
+def test_spp_precursor_list_charge_values():
+    # pyteomics parses CHARGE fields as ChargeList (a list subclass, unhashable)
+    spectra = [
+        make_spectrum_with_charge("AAA", [2], [float(i)], [1.0]) for i in range(3)
+    ] + [make_spectrum_with_charge("AAA", [3], [float(i)], [1.0]) for i in range(3)]
+    result = spectra_per_peptide(spectra, k=1, precursor=True)
+    assert len(result) == 2
+
+
 def test_spp_precursor_no_charge_field_does_not_raise():
     spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(3)]
     result = spectra_per_peptide(spectra, k=1, precursor=True)

--- a/tests/test_mgfutils.py
+++ b/tests/test_mgfutils.py
@@ -330,6 +330,91 @@ def test_spp_invalid_k_raises():
         spectra_per_peptide(spectra, k=-1)
 
 
+def make_spectrum_with_charge(seq, charge, mz, intensity):
+    s = make_spectrum(seq, mz, intensity)
+    s["params"]["charge"] = charge
+    return s
+
+
+# ---------------------------------------------------------------------------
+# spectra_per_peptide --precursor
+# ---------------------------------------------------------------------------
+
+
+def test_spp_precursor_separates_charge_states():
+    spectra = [
+        make_spectrum_with_charge("AAA", "2+", [float(i)], [1.0]) for i in range(4)
+    ] + [make_spectrum_with_charge("AAA", "3+", [float(i)], [1.0]) for i in range(4)]
+    result = spectra_per_peptide(spectra, k=2, precursor=True)
+    charges = [s["params"]["charge"] for s in result]
+    assert charges.count("2+") == 2
+    assert charges.count("3+") == 2
+
+
+def test_spp_precursor_false_merges_charge_states():
+    spectra = [
+        make_spectrum_with_charge("AAA", "2+", [float(i)], [1.0]) for i in range(4)
+    ] + [make_spectrum_with_charge("AAA", "3+", [float(i)], [1.0]) for i in range(4)]
+    result = spectra_per_peptide(spectra, k=2, precursor=False)
+    assert len(result) == 2
+
+
+def test_spp_precursor_no_charge_field_does_not_raise():
+    spectra = [make_spectrum("AAA", [float(i)], [1.0]) for i in range(3)]
+    result = spectra_per_peptide(spectra, k=1, precursor=True)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# spectra_per_peptide --ignore-mods
+# ---------------------------------------------------------------------------
+
+
+def test_spp_ignore_mods_merges_modified_forms():
+    spectra = [make_spectrum("[Acetyl]-AAA", [float(i)], [1.0]) for i in range(4)] + [
+        make_spectrum("AAA", [float(i)], [1.0]) for i in range(4)
+    ]
+    result = spectra_per_peptide(spectra, k=2, ignore_mods=True)
+    assert len(result) == 2
+
+
+def test_spp_ignore_mods_false_keeps_modified_separate():
+    spectra = [make_spectrum("[Acetyl]-AAA", [float(i)], [1.0]) for i in range(4)] + [
+        make_spectrum("AAA", [float(i)], [1.0]) for i in range(4)
+    ]
+    result = spectra_per_peptide(spectra, k=2, ignore_mods=False)
+    assert len(result) == 4
+
+
+def test_spp_ignore_mods_inline_mod():
+    spectra = [
+        make_spectrum("AAC[Carbamidomethyl]K", [float(i)], [1.0]) for i in range(3)
+    ] + [make_spectrum("AACK", [float(i)], [1.0]) for i in range(3)]
+    result = spectra_per_peptide(spectra, k=1, ignore_mods=True)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# spectra_per_peptide --precursor + --ignore-mods
+# ---------------------------------------------------------------------------
+
+
+def test_spp_precursor_and_ignore_mods_combined():
+    spectra = (
+        [
+            make_spectrum_with_charge("[Acetyl]-AAA", "2+", [float(i)], [1.0])
+            for i in range(3)
+        ]
+        + [make_spectrum_with_charge("AAA", "2+", [float(i)], [1.0]) for i in range(3)]
+        + [make_spectrum_with_charge("AAA", "3+", [float(i)], [1.0]) for i in range(3)]
+    )
+    result = spectra_per_peptide(spectra, k=1, precursor=True, ignore_mods=True)
+    charges = [s["params"]["charge"] for s in result]
+    assert len(result) == 2
+    assert charges.count("2+") == 1
+    assert charges.count("3+") == 1
+
+
 # ---------------------------------------------------------------------------
 # downsample_spectra
 # ---------------------------------------------------------------------------

--- a/tests/test_mgfutils.py
+++ b/tests/test_mgfutils.py
@@ -171,6 +171,56 @@ def test_shuffle_writes_file(tmp_path):
     assert outfile.exists()
 
 
+def _write_mgf(path, sequences):
+    """Write a minimal MGF file with one entry per sequence."""
+    with open(path, "w") as f:
+        for seq in sequences:
+            f.write("BEGIN IONS\n")
+            f.write(f"SEQ={seq}\n")
+            f.write("100.0 1.0\n")
+            f.write("END IONS\n")
+
+
+def test_shuffle_fast_path_single_file(tmp_path):
+    mgf_in = tmp_path / "input.mgf"
+    mgf_out = tmp_path / "output.mgf"
+    sequences = ["PEPTIDE", "ANOTHER", "THIRD", "FOURTH", "FIFTH"]
+    _write_mgf(mgf_in, sequences)
+
+    result = shuffle(mgf_in, outfile=mgf_out, random_seed=42)
+
+    assert result == []
+    assert mgf_out.exists()
+    content = mgf_out.read_text()
+    for seq in sequences:
+        assert content.count(f"SEQ={seq}") == 1
+
+
+def test_shuffle_fast_path_multiple_files(tmp_path):
+    mgf1 = tmp_path / "input1.mgf"
+    mgf2 = tmp_path / "input2.mgf"
+    mgf_out = tmp_path / "output.mgf"
+    seqs1 = ["PEPTIDE", "ANOTHER"]
+    seqs2 = ["THIRD", "FOURTH"]
+    _write_mgf(mgf1, seqs1)
+    _write_mgf(mgf2, seqs2)
+
+    result = shuffle([mgf1, mgf2], outfile=mgf_out, random_seed=42)
+
+    assert result == []
+    assert mgf_out.exists()
+    content = mgf_out.read_text()
+    for seq in seqs1 + seqs2:
+        assert content.count(f"SEQ={seq}") == 1
+
+
+def test_shuffle_fast_path_empty_input(tmp_path):
+    mgf_out = tmp_path / "output.mgf"
+    result = shuffle(iter([]), outfile=mgf_out)
+    assert result == []
+    assert mgf_out.exists()
+
+
 # ---------------------------------------------------------------------------
 # pipeline
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds \`_iter_raw_blocks\`: reads MGF files as raw text blocks without invoking pyteomics
- Modifies \`shuffle\` to use this fast path when input is file path(s) and \`--outfile\` is provided, avoiding the pyteomics parse/serialize round-trip
- Falls back to the existing pyteomics path when input is already-parsed spectra dicts (used internally by \`pipeline\`)

Measured speedup: writing 3M spectra reduced from ~1 hour to seconds.

## Test plan

- [ ] Run \`shuffle\` on a multi-file MGF input with \`--outfile\` and verify output spectrum count and content match the slow path
- [ ] Verify \`pipeline\` with \`do_shuffle=True\` still works (uses the existing path since it passes no \`outfile\` to \`shuffle\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable progress update frequency during spectrum iteration.
  * Implemented faster file-based spectrum shuffling, including support for multiple files and empty inputs.
  * Added charge-state and modification-aware spectrum grouping options.
  * Added warnings for malformed spectrum blocks.

* **Bug Fixes**
  * Improved cleanup after processing and command-line output handling.

* **Documentation**
  * Updated usage examples and pipeline guidance to use spectrum grouping instead of the removed downsampling command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->