### PR TITLE
Downsample mzml fix (#29)

### DIFF
--- a/src/casanovoutils/mzmlutils.py
+++ b/src/casanovoutils/mzmlutils.py
@@ -3,16 +3,13 @@ Utilities for reading and sampling spectra from mzML files.
 
 Provides a single ``sample_spectra`` command that makes one streaming pass
 through an mzML file, sampling a proportion ``k`` of spectra from each
-read buffer.  Output can be written to MGF or mzML format based on the
-output file extension.  A ``main`` entry point exposes commands as CLI
-subcommands via ``fire``.
+read buffer.  Output is written to MGF format.  A ``main`` entry point
+exposes commands as CLI subcommands via ``fire``.
 """
 
-import base64
 import logging
 import pathlib
 import random
-import zlib
 from os import PathLike
 from typing import Optional
 
@@ -21,141 +18,58 @@ import numpy as np
 import pyteomics.mgf
 import pyteomics.mzml
 import tqdm
-from lxml import etree
 
 from . import configure_logging
 from .types import Commands, PyteomicsSpectrum
 
-_MZML_NS = "http://psi.hupo.org/ms/mzml"
-_XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"
-_NSMAP = {None: _MZML_NS, "xsi": _XSI_NS}
 
+def _to_mgf_spectrum(s: PyteomicsSpectrum) -> dict:
+    """Convert a pyteomics mzML spectrum dict to pyteomics MGF spectrum format."""
+    params: dict = {"TITLE": s.get("id", "")}
 
-def _encode_array(arr: np.ndarray) -> str:
-    """Return zlib-compressed, base64-encoded float64 binary data."""
-    return base64.b64encode(zlib.compress(arr.astype(np.float64).tobytes())).decode()
+    prec_list = s.get("precursorList", {})
+    if prec_list.get("count", 0) > 0:
+        precursor = prec_list["precursor"][0]
+        sel_ions = precursor.get("selectedIonList", {})
+        if sel_ions.get("count", 0) > 0:
+            ion = sel_ions["selectedIon"][0]
+            pepmass = ion.get("selected ion m/z")
+            if pepmass is not None:
+                params["PEPMASS"] = pepmass
+            charge = ion.get("charge state")
+            if charge is not None:
+                params["CHARGE"] = f"{int(charge)}+"
 
+    scan_list = s.get("scanList", {})
+    if scan_list.get("count", 0) > 0:
+        scan = scan_list["scan"][0]
+        rt = scan.get("scan start time")
+        if rt is not None:
+            params["RTINSECONDS"] = rt
 
-def _sub(parent: etree._Element, tag: str, **attrs: str) -> etree._Element:
-    return etree.SubElement(parent, f"{{{_MZML_NS}}}{tag}", attrib=attrs)
-
-
-def _cv(parent: etree._Element, accession: str, name: str, value: str = "") -> None:
-    etree.SubElement(
-        parent,
-        f"{{{_MZML_NS}}}cvParam",
-        attrib={"cvRef": "MS", "accession": accession, "name": name, "value": value},
-    )
-
-
-def _write_mzml(spectra: list[PyteomicsSpectrum], path: PathLike) -> None:
-    """Write spectra to a minimal valid mzML 1.1.0 file."""
-    root = etree.Element(
-        f"{{{_MZML_NS}}}mzML",
-        attrib={
-            f"{{{_XSI_NS}}}schemaLocation": (
-                "http://psi.hupo.org/ms/mzml "
-                "http://psidev.info/files/ms/mzML/xsd/mzML1.1.0.xsd"
-            )
-        },
-        nsmap=_NSMAP,
-    )
-
-    cv_list = _sub(root, "cvList", count="2")
-    etree.SubElement(
-        cv_list,
-        f"{{{_MZML_NS}}}cv",
-        attrib={
-            "id": "MS",
-            "fullName": "Proteomics Standards Initiative Mass Spectrometry Ontology",
-            "version": "4.1.30",
-            "URI": "https://psidev.info/sites/default/files/2018-11/psi-ms.obo",
-        },
-    )
-    etree.SubElement(
-        cv_list,
-        f"{{{_MZML_NS}}}cv",
-        attrib={
-            "id": "UO",
-            "fullName": "Unit Ontology",
-            "version": "09:04:2014",
-            "URI": "https://raw.githubusercontent.com/bio-ontology-research-group/unit-ontology/master/unit.obo",
-        },
-    )
-
-    file_desc = _sub(root, "fileDescription")
-    _sub(file_desc, "fileContent")
-
-    sw_list = _sub(root, "softwareList", count="1")
-    sw = _sub(sw_list, "software", id="casanovoutils", version="0")
-    _cv(sw, "MS:1000799", "custom unreleased software tool", "casanovoutils")
-
-    ic_list = _sub(root, "instrumentConfigurationList", count="1")
-    ic = _sub(ic_list, "instrumentConfiguration", id="ic")
-    _cv(ic, "MS:1000031", "instrument model")
-
-    dp_list = _sub(root, "dataProcessingList", count="1")
-    dp = _sub(dp_list, "dataProcessing", id="dp")
-    pm = _sub(dp, "processingMethod", order="0", softwareRef="casanovoutils")
-    _cv(pm, "MS:1000544", "Conversion to mzML")
-
-    run = _sub(root, "run")
-    spec_list = _sub(
-        run, "spectrumList", count=str(len(spectra)), defaultDataProcessingRef="dp"
-    )
-
-    for idx, s in enumerate(spectra):
-        mz = np.asarray(s["m/z array"])
-        intensity = np.asarray(s["intensity array"])
-        ms_level = str(s.get("ms level", 2))
-        spec_id = s.get("id", f"scan={idx + 1}")
-
-        spec_el = _sub(
-            spec_list,
-            "spectrum",
-            index=str(idx),
-            id=str(spec_id),
-            defaultArrayLength=str(len(mz)),
-        )
-        _cv(spec_el, "MS:1000511", "ms level", ms_level)
-
-        bda_list = _sub(spec_el, "binaryDataArrayList", count="2")
-        for arr, accession, name in (
-            (mz, "MS:1000514", "m/z array"),
-            (intensity, "MS:1000515", "intensity array"),
-        ):
-            encoded = _encode_array(arr)
-            bda = _sub(bda_list, "binaryDataArray", encodedLength=str(len(encoded)))
-            _cv(bda, "MS:1000574", "zlib compression")
-            _cv(bda, "MS:1000523", "64-bit float")
-            _cv(bda, accession, name)
-            binary_el = etree.SubElement(bda, f"{{{_MZML_NS}}}binary")
-            binary_el.text = encoded
-
-    etree.ElementTree(root).write(
-        str(path), xml_declaration=True, encoding="utf-8", pretty_print=True
-    )
+    return {
+        "params": params,
+        "m/z array": s["m/z array"],
+        "intensity array": s["intensity array"],
+    }
 
 
 def _write_spectra(spectra: list[PyteomicsSpectrum], path: PathLike) -> None:
-    """Write spectra to MGF or mzML depending on the file extension of path."""
+    """Write spectra to MGF."""
     suffix = pathlib.Path(path).suffix.lower()
     if suffix == ".mgf":
-        out_iter = tqdm.tqdm(spectra, desc=f"Writing {path}", unit="spectrum")
+        mgf_spectra = [_to_mgf_spectrum(s) for s in spectra]
+        out_iter = tqdm.tqdm(mgf_spectra, desc=f"Writing {path}", unit="spectrum")
         pyteomics.mgf.write(out_iter, output=str(path))
-    elif suffix == ".mzml":
-        logging.info("Writing mzML to %s", path)
-        _write_mzml(spectra, path)
     else:
         raise ValueError(
-            f"Unsupported output extension {suffix!r}; expected '.mgf' or '.mzml'."
+            f"Unsupported output extension {suffix!r}; expected '.mgf'."
         )
 
 
-def sample_spectra(
+def sample_mzml(
     input_file: PathLike,
     k: float,
-    outfile: Optional[PathLike] = None,
     buffer_size: int = 1000,
     random_seed: int = 42,
 ) -> list[PyteomicsSpectrum]:
@@ -177,10 +91,6 @@ def sample_spectra(
         Path to the input mzML file.
     k : float
         Proportion of spectra to sample; must be in (0, 1).
-    outfile : PathLike, optional
-        If provided, write sampled spectra to this path.  The format is
-        determined by the file extension: ``.mgf`` writes MGF,
-        ``.mzml`` writes mzML 1.1.0.
     buffer_size : int, default=1000
         Number of spectra read per I/O chunk.
     random_seed : int, default=42
@@ -191,8 +101,6 @@ def sample_spectra(
     list[PyteomicsSpectrum]
         Sampled spectra in file order within each buffer.
     """
-    configure_logging(pathlib.Path(outfile).with_suffix(".log") if outfile else None)
-
     if not isinstance(k, float) or not (0.0 < k < 1.0):
         raise ValueError(f"k must be a float proportion in (0, 1), got {k!r}.")
 
@@ -212,11 +120,39 @@ def sample_spectra(
             result.extend(rng.sample(buf, n_sample))
 
     logging.info("Sampled %d spectra", len(result))
-
-    if outfile is not None:
-        _write_spectra(result, outfile)
-
     return result
+
+
+def sample_spectra(
+    input_file: PathLike,
+    k: float,
+    outfile: PathLike,
+    buffer_size: int = 1000,
+    random_seed: int = 42,
+) -> None:
+    """
+    Sample spectra from an mzML file and write them to an MGF file.
+    
+    Note: writing to mzML is a pain so I didn't implement it here. If you need
+    an mzML output I would recommend running this and then using msconvert
+    to convert to mzML.
+
+    Parameters
+    ----------
+    input_file : PathLike
+        Path to the input mzML file.
+    k : float
+        Proportion of spectra to sample; must be in (0, 1).
+    outfile : PathLike
+        Output path; must have a ``.mgf`` extension.
+    buffer_size : int, default=1000
+        Number of spectra read per I/O chunk.
+    random_seed : int, default=42
+        Seed for reproducible sampling.
+    """
+    configure_logging(pathlib.Path(outfile).with_suffix(".log"))
+    result = sample_mzml(input_file, k, buffer_size=buffer_size, random_seed=random_seed)
+    _write_spectra(result, outfile)
 
 
 COMMANDS: Commands = sample_spectra

--- a/tests/test_mzmlutils.py
+++ b/tests/test_mzmlutils.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pyteomics.mgf
 import pytest
 
-from casanovoutils.mzmlutils import _write_mzml, _write_spectra, sample_spectra
+from casanovoutils.mzmlutils import _to_mgf_spectrum, _write_spectra, sample_mzml, sample_spectra
 
 
 def make_spectrum(idx=0):
@@ -32,7 +33,7 @@ def _mzml_cm(spectra):
 
 
 # ---------------------------------------------------------------------------
-# sample_spectra — basic sampling
+# sample_mzml — basic sampling
 # ---------------------------------------------------------------------------
 
 
@@ -41,7 +42,7 @@ def test_returns_proportion_of_spectra():
     spectra = make_spectra(100)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        result = sample_spectra("dummy.mzML", k=0.2, buffer_size=100, random_seed=42)
+        result = sample_mzml("dummy.mzML", k=0.2, buffer_size=100, random_seed=42)
     assert len(result) == 20
 
 
@@ -50,7 +51,7 @@ def test_all_results_from_input():
     ids = {s["id"] for s in spectra}
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        result = sample_spectra("dummy.mzML", k=0.4, buffer_size=50, random_seed=42)
+        result = sample_mzml("dummy.mzML", k=0.4, buffer_size=50, random_seed=42)
     assert all(s["id"] in ids for s in result)
 
 
@@ -59,7 +60,7 @@ def test_large_proportion():
     spectra = make_spectra(100)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        result = sample_spectra("dummy.mzML", k=0.9, buffer_size=100, random_seed=42)
+        result = sample_mzml("dummy.mzML", k=0.9, buffer_size=100, random_seed=42)
     assert len(result) == 90
 
 
@@ -68,7 +69,7 @@ def test_small_proportion():
     spectra = make_spectra(100)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        result = sample_spectra("dummy.mzML", k=0.1, buffer_size=100, random_seed=42)
+        result = sample_mzml("dummy.mzML", k=0.1, buffer_size=100, random_seed=42)
     assert len(result) == 10
 
 
@@ -78,14 +79,14 @@ def test_multiple_buffers_sum_correctly():
     spectra = make_spectra(100)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        result = sample_spectra("dummy.mzML", k=0.5, buffer_size=25, random_seed=42)
+        result = sample_mzml("dummy.mzML", k=0.5, buffer_size=25, random_seed=42)
     assert len(result) == 4 * round(0.5 * 25)
 
 
 def test_empty_input_returns_empty():
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm([])
-        result = sample_spectra("dummy.mzML", k=0.5, random_seed=42)
+        result = sample_mzml("dummy.mzML", k=0.5, random_seed=42)
     assert result == []
 
 
@@ -93,10 +94,10 @@ def test_reproducible_same_seed():
     spectra = make_spectra(50)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        r1 = sample_spectra("dummy.mzML", k=0.5, buffer_size=50, random_seed=7)
+        r1 = sample_mzml("dummy.mzML", k=0.5, buffer_size=50, random_seed=7)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        r2 = sample_spectra("dummy.mzML", k=0.5, buffer_size=50, random_seed=7)
+        r2 = sample_mzml("dummy.mzML", k=0.5, buffer_size=50, random_seed=7)
     assert [s["id"] for s in r1] == [s["id"] for s in r2]
 
 
@@ -104,54 +105,54 @@ def test_different_seeds_differ():
     spectra = make_spectra(100)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        r1 = sample_spectra("dummy.mzML", k=0.5, buffer_size=100, random_seed=1)
+        r1 = sample_mzml("dummy.mzML", k=0.5, buffer_size=100, random_seed=1)
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_cls:
         mock_cls.return_value = _mzml_cm(spectra)
-        r2 = sample_spectra("dummy.mzML", k=0.5, buffer_size=100, random_seed=2)
+        r2 = sample_mzml("dummy.mzML", k=0.5, buffer_size=100, random_seed=2)
     assert [s["id"] for s in r1] != [s["id"] for s in r2]
 
 
 # ---------------------------------------------------------------------------
-# sample_spectra — validation
+# sample_mzml — validation
 # ---------------------------------------------------------------------------
 
 
 def test_k_int_raises():
     with pytest.raises(ValueError, match=r"\(0, 1\)"):
-        sample_spectra("dummy.mzML", k=1)
+        sample_mzml("dummy.mzML", k=1)
 
 
 def test_k_float_one_raises():
     with pytest.raises(ValueError, match=r"\(0, 1\)"):
-        sample_spectra("dummy.mzML", k=1.0)
+        sample_mzml("dummy.mzML", k=1.0)
 
 
 def test_k_float_greater_than_one_raises():
     with pytest.raises(ValueError, match=r"\(0, 1\)"):
-        sample_spectra("dummy.mzML", k=1.5)
+        sample_mzml("dummy.mzML", k=1.5)
 
 
 def test_k_float_zero_raises():
     with pytest.raises(ValueError, match=r"\(0, 1\)"):
-        sample_spectra("dummy.mzML", k=0.0)
+        sample_mzml("dummy.mzML", k=0.0)
 
 
 def test_k_float_negative_raises():
     with pytest.raises(ValueError, match=r"\(0, 1\)"):
-        sample_spectra("dummy.mzML", k=-0.5)
+        sample_mzml("dummy.mzML", k=-0.5)
 
 
 def test_k_string_raises():
     with pytest.raises(ValueError, match=r"\(0, 1\)"):
-        sample_spectra("dummy.mzML", k="half")
+        sample_mzml("dummy.mzML", k="half")
 
 
 # ---------------------------------------------------------------------------
-# sample_spectra — outfile dispatch
+# sample_spectra — CLI dispatch
 # ---------------------------------------------------------------------------
 
 
-def test_mgf_outfile_calls_mgf_write(tmp_path):
+def test_sample_spectra_calls_mgf_write(tmp_path):
     spectra = make_spectra(10)
     outfile = tmp_path / "out.mgf"
     with (
@@ -159,69 +160,129 @@ def test_mgf_outfile_calls_mgf_write(tmp_path):
         patch("casanovoutils.mzmlutils.pyteomics.mgf.write") as mock_write,
     ):
         mock_mzml.return_value = _mzml_cm(spectra)
-        sample_spectra(
-            "dummy.mzML", k=0.5, outfile=outfile, buffer_size=10, random_seed=42
-        )
+        sample_spectra("dummy.mzML", k=0.5, outfile=outfile, buffer_size=10, random_seed=42)
     mock_write.assert_called_once()
 
 
-def test_mzml_outfile_calls_write_mzml(tmp_path):
+def test_sample_spectra_returns_none(tmp_path):
     spectra = make_spectra(10)
-    outfile = tmp_path / "out.mzml"
+    outfile = tmp_path / "out.mgf"
     with (
         patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_mzml,
-        patch("casanovoutils.mzmlutils._write_mzml") as mock_write,
+        patch("casanovoutils.mzmlutils.pyteomics.mgf.write"),
     ):
         mock_mzml.return_value = _mzml_cm(spectra)
-        sample_spectra(
-            "dummy.mzML", k=0.5, outfile=outfile, buffer_size=10, random_seed=42
-        )
-    mock_write.assert_called_once()
+        result = sample_spectra("dummy.mzML", k=0.5, outfile=outfile, buffer_size=10, random_seed=42)
+    assert result is None
 
 
-def test_no_write_when_outfile_none():
-    spectra = make_spectra(10)
-    with (
-        patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_mzml,
-        patch("casanovoutils.mzmlutils.pyteomics.mgf.write") as mock_write,
-        patch("casanovoutils.mzmlutils._write_mzml") as mock_mzml_write,
-    ):
-        mock_mzml.return_value = _mzml_cm(spectra)
-        sample_spectra("dummy.mzML", k=0.5, random_seed=42)
-    mock_write.assert_not_called()
-    mock_mzml_write.assert_not_called()
-
-
-def test_unsupported_extension_raises(tmp_path):
+def test_sample_spectra_unsupported_extension_raises(tmp_path):
     spectra = make_spectra(10)
     outfile = tmp_path / "out.csv"
     with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_mzml:
         mock_mzml.return_value = _mzml_cm(spectra)
         with pytest.raises(ValueError, match="Unsupported output extension"):
-            sample_spectra(
-                "dummy.mzML", k=0.5, outfile=outfile, buffer_size=10, random_seed=42
-            )
+            sample_spectra("dummy.mzML", k=0.5, outfile=outfile, buffer_size=10, random_seed=42)
+
+
+def test_sample_spectra_mzml_extension_raises(tmp_path):
+    spectra = make_spectra(10)
+    outfile = tmp_path / "out.mzml"
+    with patch("casanovoutils.mzmlutils.pyteomics.mzml.MzML") as mock_mzml:
+        mock_mzml.return_value = _mzml_cm(spectra)
+        with pytest.raises(ValueError, match="Unsupported output extension"):
+            sample_spectra("dummy.mzML", k=0.5, outfile=outfile, buffer_size=10, random_seed=42)
 
 
 # ---------------------------------------------------------------------------
-# _write_mzml — round-trip
+# _to_mgf_spectrum
 # ---------------------------------------------------------------------------
 
 
-def test_write_mzml_roundtrip(tmp_path):
-    spectra = make_spectra(5)
-    out = tmp_path / "out.mzml"
-    _write_mzml(spectra, out)
-    import pyteomics.mzml
+def test_to_mgf_spectrum_has_params_key():
+    s = make_spectrum(0)
+    result = _to_mgf_spectrum(s)
+    assert "params" in result
 
-    with pyteomics.mzml.MzML(str(out)) as reader:
-        result = list(reader)
-    assert len(result) == 5
-    for orig, read in zip(spectra, result):
-        np.testing.assert_allclose(orig["m/z array"], read["m/z array"], rtol=1e-6)
-        np.testing.assert_allclose(
-            orig["intensity array"], read["intensity array"], rtol=1e-6
-        )
+
+def test_to_mgf_spectrum_title_from_id():
+    s = make_spectrum(0)
+    result = _to_mgf_spectrum(s)
+    assert result["params"]["TITLE"] == "scan=1"
+
+
+def test_to_mgf_spectrum_preserves_arrays():
+    s = make_spectrum(3)
+    result = _to_mgf_spectrum(s)
+    np.testing.assert_array_equal(result["m/z array"], s["m/z array"])
+    np.testing.assert_array_equal(result["intensity array"], s["intensity array"])
+
+
+def test_to_mgf_spectrum_no_precursor_no_pepmass():
+    s = make_spectrum(0)
+    result = _to_mgf_spectrum(s)
+    assert "PEPMASS" not in result["params"]
+    assert "CHARGE" not in result["params"]
+
+
+def test_to_mgf_spectrum_with_precursor():
+    s = make_spectrum(0)
+    s["precursorList"] = {
+        "count": 1,
+        "precursor": [
+            {
+                "selectedIonList": {
+                    "count": 1,
+                    "selectedIon": [
+                        {"selected ion m/z": 500.25, "peak intensity": 1e5, "charge state": 2}
+                    ],
+                }
+            }
+        ],
+    }
+    result = _to_mgf_spectrum(s)
+    assert result["params"]["PEPMASS"] == 500.25
+    assert result["params"]["CHARGE"] == "2+"
+
+
+def test_to_mgf_spectrum_precursor_no_intensity():
+    s = make_spectrum(0)
+    s["precursorList"] = {
+        "count": 1,
+        "precursor": [
+            {
+                "selectedIonList": {
+                    "count": 1,
+                    "selectedIon": [{"selected ion m/z": 612.3, "charge state": 3}],
+                }
+            }
+        ],
+    }
+    result = _to_mgf_spectrum(s)
+    assert result["params"]["PEPMASS"] == 612.3
+    assert result["params"]["CHARGE"] == "3+"
+
+
+def test_to_mgf_spectrum_with_retention_time():
+    s = make_spectrum(0)
+    s["scanList"] = {
+        "count": 1,
+        "scan": [{"scan start time": 123.45}],
+    }
+    result = _to_mgf_spectrum(s)
+    assert result["params"]["RTINSECONDS"] == 123.45
+
+
+def test_to_mgf_spectrum_missing_id_uses_empty_title():
+    s = make_spectrum(0)
+    del s["id"]
+    result = _to_mgf_spectrum(s)
+    assert result["params"]["TITLE"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _write_spectra — MGF round-trip
+# ---------------------------------------------------------------------------
 
 
 def test_write_spectra_mgf_dispatch(tmp_path):
@@ -232,14 +293,65 @@ def test_write_spectra_mgf_dispatch(tmp_path):
     mock_write.assert_called_once()
 
 
-def test_write_spectra_mzml_dispatch(tmp_path):
-    spectra = make_spectra(3)
-    outfile = tmp_path / "out.mzml"
-    with patch("casanovoutils.mzmlutils._write_mzml") as mock_write:
-        _write_spectra(spectra, outfile)
-    mock_write.assert_called_once_with(spectra, outfile)
-
-
 def test_write_spectra_bad_extension_raises(tmp_path):
     with pytest.raises(ValueError, match="Unsupported output extension"):
         _write_spectra([], tmp_path / "out.txt")
+
+
+def test_write_spectra_mzml_extension_raises(tmp_path):
+    with pytest.raises(ValueError, match="Unsupported output extension"):
+        _write_spectra([], tmp_path / "out.mzml")
+
+
+def test_write_spectra_mgf_roundtrip(tmp_path):
+    spectra = make_spectra(5)
+    outfile = tmp_path / "out.mgf"
+    _write_spectra(spectra, outfile)
+    with pyteomics.mgf.read(str(outfile)) as reader:
+        result = list(reader)
+    assert len(result) == 5
+    for orig, read in zip(spectra, result):
+        np.testing.assert_allclose(orig["m/z array"], read["m/z array"], rtol=1e-5)
+        np.testing.assert_allclose(
+            orig["intensity array"], read["intensity array"], rtol=1e-5
+        )
+
+
+def test_write_spectra_mgf_roundtrip_titles(tmp_path):
+    spectra = make_spectra(3)
+    outfile = tmp_path / "out.mgf"
+    _write_spectra(spectra, outfile)
+    with pyteomics.mgf.read(str(outfile)) as reader:
+        result = list(reader)
+    titles = [r["params"]["title"] for r in result]
+    assert titles == ["scan=1", "scan=2", "scan=3"]
+
+
+def test_write_spectra_mgf_with_precursor_roundtrip(tmp_path):
+    s = make_spectrum(0)
+    s["precursorList"] = {
+        "count": 1,
+        "precursor": [
+            {
+                "selectedIonList": {
+                    "count": 1,
+                    "selectedIon": [{"selected ion m/z": 800.5, "charge state": 2}],
+                }
+            }
+        ],
+    }
+    outfile = tmp_path / "out.mgf"
+    _write_spectra([s], outfile)
+    with pyteomics.mgf.read(str(outfile)) as reader:
+        result = list(reader)
+    assert len(result) == 1
+    assert result[0]["params"]["charge"] == [2]
+    assert abs(result[0]["params"]["pepmass"][0] - 800.5) < 1e-3
+
+
+def test_write_spectra_mgf_empty(tmp_path):
+    outfile = tmp_path / "out.mgf"
+    _write_spectra([], outfile)
+    with pyteomics.mgf.read(str(outfile)) as reader:
+        result = list(reader)
+    assert result == []


### PR DESCRIPTION
* downgrade python version

* mzml downsample

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed mzML output format support; the tool now exclusively produces MGF-format files.
  * Unsupported file extensions now raise errors instead of being silently processed.

* **Improvements**
  * Enhanced spectrum sampling and conversion logic for improved data handling.

* **API Updates**
  * Modified spectrum sampling function signatures and behavior.
  * Added new function for direct spectrum sampling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->