### PR TITLE
Fix I/L leakage in dataset splitting

### DIFF
--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -42,7 +42,19 @@ def _canonical(seq: str) -> str:
     str
         Canonical peptide sequence.
     """
-    seq = seq.replace("I", "L")
+    # Replace I with L only at residue positions (bracket depth 0), so that
+    # uppercase I characters inside modification names are left untouched.
+    chars = []
+    depth = 0
+    for ch in seq:
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+        elif ch == "I" and depth == 0:
+            ch = "L"
+        chars.append(ch)
+    seq = "".join(chars)
     seq = seq.replace("N[Deamidated]", "D")
     seq = seq.replace("Q[Deamidated]", "E")
     return seq

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -17,31 +17,40 @@ from .types import Commands
 _WRITE_BUFFER_SIZE = 1000
 
 
-def _canonical(seq: str, normalize_il: bool) -> str:
+def _canonical(seq: str, normalize_isobaric: bool) -> str:
     """Return the canonical form of a peptide sequence.
 
-    When *normalize_il* is True, isoleucine (I) is replaced with leucine (L)
-    so that sequences that are indistinguishable by mass spectrometry are
-    treated as identical during splitting.
+    When *normalize_isobaric* is True, residues that are indistinguishable by
+    mass spectrometry are mapped to a single representative token:
+
+    * Isoleucine (I) → Leucine (L)  [identical mass]
+    * N[Deamidated] → D  [deamidation of Asn yields Asp; identical mass]
+    * Q[Deamidated] → E  [deamidation of Gln yields Glu; identical mass]
 
     Parameters
     ----------
     seq : str
-        Peptide sequence.
-    normalize_il : bool
-        If True, replace I with L.
+        Peptide sequence, optionally containing bracket-enclosed modifications
+        in the form ``AA[ModName]``.
+    normalize_isobaric : bool
+        If True, apply all isobaric substitutions listed above.
 
     Returns
     -------
     str
         Canonical peptide sequence.
     """
-    return seq.replace("I", "L") if normalize_il else seq
+    if not normalize_isobaric:
+        return seq
+    seq = seq.replace("I", "L")
+    seq = seq.replace("N[Deamidated]", "D")
+    seq = seq.replace("Q[Deamidated]", "E")
+    return seq
 
 
 def _collect_peptide_counts(
     mgf_files: tuple[PathLike, ...],
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], int]:
     """Pass 1: stream all input MGF files and count spectra per peptide.
 
@@ -76,7 +85,7 @@ def _collect_peptide_counts(
                     f"Missing 'seq' in spectrum params for spectrum "
                     f"{spectrum_index} in file {mgf_file}"
                 ) from exc
-            key = _canonical(seq, normalize_il)
+            key = _canonical(seq, normalize_isobaric)
             pep_counts[key] = pep_counts.get(key, 0) + 1
             file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
@@ -92,7 +101,7 @@ def _assign_splits(
     total_spectra: int,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     spectra_per_peptide: Optional[int],
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, str], dict[str, set[int]], dict[str, set[str]]]:
     """Compute per-peptide split assignments and sampling indices.
 
@@ -108,9 +117,10 @@ def _assign_splits(
         Paths to existing train/val/test MGF files, or None.
     spectra_per_peptide : int or None
         Maximum spectra to retain per peptide, or None.
-    normalize_il : bool, default=True
-        If True, isoleucine (I) is replaced with leucine (L) when comparing
-        peptide sequences, matching the behavior of ``_collect_peptide_counts``.
+    normalize_isobaric : bool, default=True
+        If True, isobaric residues are canonicalized when comparing peptide
+        sequences, matching the behavior of ``_collect_peptide_counts``.
+        See ``_canonical`` for the full set of substitutions applied.
 
     Returns
     -------
@@ -171,7 +181,7 @@ def _assign_splits(
                         f"existing split '{split_name}' from file "
                         f"'{split_path}'"
                     ) from exc
-                existing_peps[split_name].add(_canonical(seq, normalize_il))
+                existing_peps[split_name].add(_canonical(seq, normalize_isobaric))
             logging.info(
                 f"Existing {split_name}: "
                 f"{len(existing_peps[split_name])} peptide"
@@ -325,7 +335,7 @@ def _write_splits(
     spectra_per_peptide: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
     """Pass 2: stream spectra to output MGF files.
 
@@ -345,10 +355,10 @@ def _write_splits(
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
         If True, prepend existing split spectra to each output file.
-    normalize_il : bool, default=True
-        If True, isoleucine (I) is replaced with leucine (L) when looking up
-        each spectrum's split assignment. Original sequences are preserved in
-        the output MGF files.
+    normalize_isobaric : bool, default=True
+        If True, isobaric residues are canonicalized when looking up each
+        spectrum's split assignment. Original sequences are preserved in the
+        output MGF files. See ``_canonical`` for the substitutions applied.
 
     Returns
     -------
@@ -426,7 +436,7 @@ def _write_splits(
                 unit="PSM",
             ):
                 seq = spectrum["params"]["seq"]
-                key = _canonical(seq, normalize_il)
+                key = _canonical(seq, normalize_isobaric)
 
                 # Apply spectra_per_peptide filtering.
                 if spectra_per_peptide is not None:
@@ -457,7 +467,7 @@ def create_datasets(
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -467,12 +477,19 @@ def create_datasets(
     based on their associated peptide, ensuring no peptide-level leakage
     between splits.
 
-    Because mass spectrometry cannot distinguish isoleucine (I) from leucine
-    (L), peptides that differ only at I/L positions are indistinguishable and
-    should always be placed in the same split. By default (``normalize_il=True``)
-    the splitting key replaces I with L before grouping, so all I/L variants of
-    a peptide are treated as one entity. The original sequences are preserved
-    unchanged in the output MGF files.
+    Several pairs of residues are indistinguishable by mass spectrometry and
+    must always be placed in the same split to prevent leakage:
+
+    * Isoleucine (I) and leucine (L) have identical masses.
+    * Deamidated asparagine (N[Deamidated]) and aspartic acid (D) have
+      identical masses.
+    * Deamidated glutamine (Q[Deamidated]) and glutamic acid (E) have
+      identical masses.
+
+    By default (``normalize_isobaric=True``), each spectrum's peptide sequence
+    is mapped to a canonical form before the split assignment is looked up, so
+    all mass-equivalent variants are grouped together. The original sequences
+    are preserved unchanged in the output MGF files.
 
     Parameters
     ----------
@@ -501,11 +518,12 @@ def create_datasets(
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
-    normalize_il : bool, default=True
-        If True, isoleucine (I) is replaced with leucine (L) when grouping
-        peptides for splitting. This prevents train/test leakage between
-        peptides that are indistinguishable by mass spectrometry. Original
-        sequences are preserved in the output MGF files.
+    normalize_isobaric : bool, default=True
+        If True, mass-equivalent residues are canonicalized before peptides
+        are grouped for splitting, preventing train/test leakage between
+        sequences that are indistinguishable by mass spectrometry (I/L,
+        N[Deamidated]/D, Q[Deamidated]/E). Original sequences are preserved
+        in the output MGF files.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -539,14 +557,14 @@ def create_datasets(
 
     random.seed(random_seed)
 
-    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_il)
+    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_isobaric)
 
     pep_to_split, sampled_indices, existing_peps = _assign_splits(
         pep_counts,
         total_spectra,
         existing_splits,
         spectra_per_peptide,
-        normalize_il,
+        normalize_isobaric,
     )
 
     split_spectra_counts, split_pep_sets = _write_splits(
@@ -557,7 +575,7 @@ def create_datasets(
         spectra_per_peptide,
         existing_splits,
         combine_with_existing,
-        normalize_il,
+        normalize_isobaric,
     )
 
     # Log split summaries.

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -17,8 +17,31 @@ from .types import Commands
 _WRITE_BUFFER_SIZE = 1000
 
 
+def _canonical(seq: str, normalize_il: bool) -> str:
+    """Return the canonical form of a peptide sequence.
+
+    When *normalize_il* is True, isoleucine (I) is replaced with leucine (L)
+    so that sequences that are indistinguishable by mass spectrometry are
+    treated as identical during splitting.
+
+    Parameters
+    ----------
+    seq : str
+        Peptide sequence.
+    normalize_il : bool
+        If True, replace I with L.
+
+    Returns
+    -------
+    str
+        Canonical peptide sequence.
+    """
+    return seq.replace("I", "L") if normalize_il else seq
+
+
 def _collect_peptide_counts(
     mgf_files: tuple[PathLike, ...],
+    normalize_il: bool = True,
 ) -> tuple[dict[str, int], int]:
     """Pass 1: stream all input MGF files and count spectra per peptide.
 
@@ -30,7 +53,7 @@ def _collect_peptide_counts(
     Returns
     -------
     pep_counts : dict[str, int]
-        Mapping of peptide sequence to spectrum count.
+        Mapping of canonical peptide sequence to spectrum count.
     total_spectra : int
         Total number of spectra read across all files.
     """
@@ -53,7 +76,8 @@ def _collect_peptide_counts(
                     f"Missing 'seq' in spectrum params for spectrum "
                     f"{spectrum_index} in file {mgf_file}"
                 ) from exc
-            pep_counts[seq] = pep_counts.get(seq, 0) + 1
+            key = _canonical(seq, normalize_il)
+            pep_counts[key] = pep_counts.get(key, 0) + 1
             file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
         total_spectra += file_count
@@ -68,6 +92,7 @@ def _assign_splits(
     total_spectra: int,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     spectra_per_peptide: Optional[int],
+    normalize_il: bool = True,
 ) -> tuple[dict[str, str], dict[str, set[int]], dict[str, set[str]]]:
     """Compute per-peptide split assignments and sampling indices.
 
@@ -83,11 +108,15 @@ def _assign_splits(
         Paths to existing train/val/test MGF files, or None.
     spectra_per_peptide : int or None
         Maximum spectra to retain per peptide, or None.
+    normalize_il : bool, default=True
+        If True, isoleucine (I) is replaced with leucine (L) when comparing
+        peptide sequences, matching the behavior of ``_collect_peptide_counts``.
 
     Returns
     -------
     pep_to_split : dict[str, str]
-        Mapping of peptide sequence to split name ("train", "val", "test").
+        Mapping of canonical peptide sequence to split name
+        ("train", "val", "test").
     sampled_indices : dict[str, set[int]]
         For peptides that exceed spectra_per_peptide, the 0-based indices
         of spectra to retain. Empty dict if spectra_per_peptide is None.
@@ -142,7 +171,7 @@ def _assign_splits(
                         f"existing split '{split_name}' from file "
                         f"'{split_path}'"
                     ) from exc
-                existing_peps[split_name].add(seq)
+                existing_peps[split_name].add(_canonical(seq, normalize_il))
             logging.info(
                 f"Existing {split_name}: "
                 f"{len(existing_peps[split_name])} peptide"
@@ -296,6 +325,7 @@ def _write_splits(
     spectra_per_peptide: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
+    normalize_il: bool = True,
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
     """Pass 2: stream spectra to output MGF files.
 
@@ -315,6 +345,10 @@ def _write_splits(
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
         If True, prepend existing split spectra to each output file.
+    normalize_il : bool, default=True
+        If True, isoleucine (I) is replaced with leucine (L) when looking up
+        each spectrum's split assignment. Original sequences are preserved in
+        the output MGF files.
 
     Returns
     -------
@@ -392,18 +426,19 @@ def _write_splits(
                 unit="PSM",
             ):
                 seq = spectrum["params"]["seq"]
+                key = _canonical(seq, normalize_il)
 
                 # Apply spectra_per_peptide filtering.
                 if spectra_per_peptide is not None:
-                    idx = pep_counters.get(seq, 0)
-                    pep_counters[seq] = idx + 1
-                    if seq in sampled_indices:
-                        if idx not in sampled_indices[seq]:
+                    idx = pep_counters.get(key, 0)
+                    pep_counters[key] = idx + 1
+                    if key in sampled_indices:
+                        if idx not in sampled_indices[key]:
                             continue
-                    # If seq not in sampled_indices, count <= limit,
+                    # If key not in sampled_indices, count <= limit,
                     # so keep all.
 
-                split_name = pep_to_split.get(seq)
+                split_name = pep_to_split.get(key)
                 if split_name is not None:
                     write_spectrum(split_name, spectrum)
 
@@ -422,6 +457,7 @@ def create_datasets(
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
+    normalize_il: bool = True,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -430,6 +466,13 @@ def create_datasets(
     validation (10%), and test (10%) sets. Spectra are then assigned to splits
     based on their associated peptide, ensuring no peptide-level leakage
     between splits.
+
+    Because mass spectrometry cannot distinguish isoleucine (I) from leucine
+    (L), peptides that differ only at I/L positions are indistinguishable and
+    should always be placed in the same split. By default (``normalize_il=True``)
+    the splitting key replaces I with L before grouping, so all I/L variants of
+    a peptide are treated as one entity. The original sequences are preserved
+    unchanged in the output MGF files.
 
     Parameters
     ----------
@@ -458,6 +501,11 @@ def create_datasets(
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
+    normalize_il : bool, default=True
+        If True, isoleucine (I) is replaced with leucine (L) when grouping
+        peptides for splitting. This prevents train/test leakage between
+        peptides that are indistinguishable by mass spectrometry. Original
+        sequences are preserved in the output MGF files.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -491,13 +539,14 @@ def create_datasets(
 
     random.seed(random_seed)
 
-    pep_counts, total_spectra = _collect_peptide_counts(mgf_files)
+    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_il)
 
     pep_to_split, sampled_indices, existing_peps = _assign_splits(
         pep_counts,
         total_spectra,
         existing_splits,
         spectra_per_peptide,
+        normalize_il,
     )
 
     split_spectra_counts, split_pep_sets = _write_splits(
@@ -508,6 +557,7 @@ def create_datasets(
         spectra_per_peptide,
         existing_splits,
         combine_with_existing,
+        normalize_il,
     )
 
     # Log split summaries.

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -17,31 +17,31 @@ from .types import Commands
 _WRITE_BUFFER_SIZE = 1000
 
 
-def _canonical(seq: str, normalize_isobaric: bool) -> str:
+def _canonical(seq: str) -> str:
     """Return the canonical form of a peptide sequence.
 
-    When *normalize_isobaric* is True, residues that are indistinguishable by
-    mass spectrometry are mapped to a single representative token:
+    Residues that are indistinguishable by mass spectrometry are mapped to a
+    single representative token so that mass-equivalent variants are always
+    grouped together during splitting:
 
     * Isoleucine (I) → Leucine (L)  [identical mass]
     * N[Deamidated] → D  [deamidation of Asn yields Asp; identical mass]
     * Q[Deamidated] → E  [deamidation of Gln yields Glu; identical mass]
+
+    The canonical form is used only as a grouping key; original sequences are
+    preserved unchanged in the output MGF files.
 
     Parameters
     ----------
     seq : str
         Peptide sequence, optionally containing bracket-enclosed modifications
         in the form ``AA[ModName]``.
-    normalize_isobaric : bool
-        If True, apply all isobaric substitutions listed above.
 
     Returns
     -------
     str
         Canonical peptide sequence.
     """
-    if not normalize_isobaric:
-        return seq
     seq = seq.replace("I", "L")
     seq = seq.replace("N[Deamidated]", "D")
     seq = seq.replace("Q[Deamidated]", "E")
@@ -50,7 +50,6 @@ def _canonical(seq: str, normalize_isobaric: bool) -> str:
 
 def _collect_peptide_counts(
     mgf_files: tuple[PathLike, ...],
-    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], int]:
     """Pass 1: stream all input MGF files and count spectra per peptide.
 
@@ -85,7 +84,7 @@ def _collect_peptide_counts(
                     f"Missing 'seq' in spectrum params for spectrum "
                     f"{spectrum_index} in file {mgf_file}"
                 ) from exc
-            key = _canonical(seq, normalize_isobaric)
+            key = _canonical(seq)
             pep_counts[key] = pep_counts.get(key, 0) + 1
             file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
@@ -101,7 +100,6 @@ def _assign_splits(
     total_spectra: int,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     spectra_per_peptide: Optional[int],
-    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, str], dict[str, set[int]], dict[str, set[str]]]:
     """Compute per-peptide split assignments and sampling indices.
 
@@ -110,17 +108,13 @@ def _assign_splits(
     Parameters
     ----------
     pep_counts : dict[str, int]
-        Mapping of peptide sequence to spectrum count from pass 1.
+        Mapping of canonical peptide sequence to spectrum count from pass 1.
     total_spectra : int
         Total spectra across all input files.
     existing_splits : tuple of PathLike or None
         Paths to existing train/val/test MGF files, or None.
     spectra_per_peptide : int or None
         Maximum spectra to retain per peptide, or None.
-    normalize_isobaric : bool, default=True
-        If True, isobaric residues are canonicalized when comparing peptide
-        sequences, matching the behavior of ``_collect_peptide_counts``.
-        See ``_canonical`` for the full set of substitutions applied.
 
     Returns
     -------
@@ -131,8 +125,8 @@ def _assign_splits(
         For peptides that exceed spectra_per_peptide, the 0-based indices
         of spectra to retain. Empty dict if spectra_per_peptide is None.
     existing_peps : dict[str, set[str]]
-        Peptides already present in each existing split. Empty sets if
-        existing_splits is None.
+        Canonical peptides already present in each existing split. Empty sets
+        if existing_splits is None.
     """
     # Pre-compute which spectrum indices to keep for each peptide when
     # spectra_per_peptide is set.
@@ -181,7 +175,7 @@ def _assign_splits(
                         f"existing split '{split_name}' from file "
                         f"'{split_path}'"
                     ) from exc
-                existing_peps[split_name].add(_canonical(seq, normalize_isobaric))
+                existing_peps[split_name].add(_canonical(seq))
             logging.info(
                 f"Existing {split_name}: "
                 f"{len(existing_peps[split_name])} peptide"
@@ -335,7 +329,6 @@ def _write_splits(
     spectra_per_peptide: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
-    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
     """Pass 2: stream spectra to output MGF files.
 
@@ -346,7 +339,7 @@ def _write_splits(
     output_root : str
         Root path for output files.
     pep_to_split : dict[str, str]
-        Mapping from peptide sequence to split name.
+        Mapping from canonical peptide sequence to split name.
     sampled_indices : dict[str, set[int]]
         Per-peptide sets of 0-based spectrum indices to retain.
     spectra_per_peptide : int or None
@@ -355,17 +348,13 @@ def _write_splits(
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
         If True, prepend existing split spectra to each output file.
-    normalize_isobaric : bool, default=True
-        If True, isobaric residues are canonicalized when looking up each
-        spectrum's split assignment. Original sequences are preserved in the
-        output MGF files. See ``_canonical`` for the substitutions applied.
 
     Returns
     -------
     split_spectra_counts : dict[str, int]
         Number of spectra written to each split.
     split_pep_sets : dict[str, set[str]]
-        Set of new peptides assigned to each split.
+        Set of new canonical peptides assigned to each split.
     """
     split_pep_sets = {
         split: {pep for pep, s in pep_to_split.items() if s == split}
@@ -436,7 +425,7 @@ def _write_splits(
                 unit="PSM",
             ):
                 seq = spectrum["params"]["seq"]
-                key = _canonical(seq, normalize_isobaric)
+                key = _canonical(seq)
 
                 # Apply spectra_per_peptide filtering.
                 if spectra_per_peptide is not None:
@@ -467,7 +456,6 @@ def create_datasets(
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
-    normalize_isobaric: bool = True,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -478,7 +466,7 @@ def create_datasets(
     between splits.
 
     Several pairs of residues are indistinguishable by mass spectrometry and
-    must always be placed in the same split to prevent leakage:
+    are always grouped together during splitting to prevent leakage:
 
     * Isoleucine (I) and leucine (L) have identical masses.
     * Deamidated asparagine (N[Deamidated]) and aspartic acid (D) have
@@ -486,10 +474,10 @@ def create_datasets(
     * Deamidated glutamine (Q[Deamidated]) and glutamic acid (E) have
       identical masses.
 
-    By default (``normalize_isobaric=True``), each spectrum's peptide sequence
-    is mapped to a canonical form before the split assignment is looked up, so
-    all mass-equivalent variants are grouped together. The original sequences
-    are preserved unchanged in the output MGF files.
+    Each spectrum's peptide sequence is mapped to a canonical form (see
+    ``_canonical``) before the split assignment is looked up, so all
+    mass-equivalent variants are always grouped together. The original
+    sequences are preserved unchanged in the output MGF files.
 
     Parameters
     ----------
@@ -518,12 +506,6 @@ def create_datasets(
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
-    normalize_isobaric : bool, default=True
-        If True, mass-equivalent residues are canonicalized before peptides
-        are grouped for splitting, preventing train/test leakage between
-        sequences that are indistinguishable by mass spectrometry (I/L,
-        N[Deamidated]/D, Q[Deamidated]/E). Original sequences are preserved
-        in the output MGF files.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -557,14 +539,13 @@ def create_datasets(
 
     random.seed(random_seed)
 
-    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_isobaric)
+    pep_counts, total_spectra = _collect_peptide_counts(mgf_files)
 
     pep_to_split, sampled_indices, existing_peps = _assign_splits(
         pep_counts,
         total_spectra,
         existing_splits,
         spectra_per_peptide,
-        normalize_isobaric,
     )
 
     split_spectra_counts, split_pep_sets = _write_splits(
@@ -575,7 +556,6 @@ def create_datasets(
         spectra_per_peptide,
         existing_splits,
         combine_with_existing,
-        normalize_isobaric,
     )
 
     # Log split summaries.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -719,9 +719,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return split_name
             return None
 
-        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
-            "I/L variants must land in the same split"
-        )
+        assert find_split("PEPTIDE") == find_split(
+            "PEPTLDE"
+        ), "I/L variants must land in the same split"
 
     def test_il_variants_counted_as_one_peptide(self, tmp_path):
         """I/L variants count as a single peptide due to isobaric normalization."""
@@ -757,9 +757,9 @@ class TestCreateDatasetsIsobaricNormalization:
                         return name
                 return None
 
-            assert find_split(i_seq) == find_split(l_seq), (
-                f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
-            )
+            assert find_split(i_seq) == find_split(
+                l_seq
+            ), f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
 
     def test_isobaric_normalization_is_unconditional(self, tmp_path):
         """Isobaric normalization is always applied; there is no opt-out."""
@@ -811,7 +811,8 @@ class TestCreateDatasetsIsobaricNormalization:
         # Existing train split contains PEPTLDE (L-form).
         train_path = _write_mgf(
             tmp_path / "exist_train.mgf",
-            [("PEPTLDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+            [("PEPTLDE", [100.0], [1.0])]
+            + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
         )
         val_path = _write_mgf(
             tmp_path / "exist_val.mgf",
@@ -826,7 +827,8 @@ class TestCreateDatasetsIsobaricNormalization:
         # New data has PEPTIDE (I-form), the I/L variant of PEPTLDE.
         mgf = _write_mgf(
             tmp_path / "new.mgf",
-            [("PEPTIDE", [100.0], [1.0])] + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
+            [("PEPTIDE", [100.0], [1.0])]
+            + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
         )
         output_root = str(tmp_path / "out")
 
@@ -869,9 +871,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
-            "Default behavior must place I/L variants in the same split"
-        )
+        assert find_split("PEPTIDE") == find_split(
+            "PEPTLDE"
+        ), "Default behavior must place I/L variants in the same split"
 
     def test_deamidated_n_and_d_land_in_same_split(self, tmp_path):
         """N[Deamidated] and D variants of the same peptide land in the same split."""
@@ -896,9 +898,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTN[Deamidated]DE") == find_split("PEPTDDE"), (
-            "N[Deamidated] and D variants must land in the same split"
-        )
+        assert find_split("PEPTN[Deamidated]DE") == find_split(
+            "PEPTDDE"
+        ), "N[Deamidated] and D variants must land in the same split"
 
     def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
         """Q[Deamidated] and E variants of the same peptide land in the same split."""
@@ -923,9 +925,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTQ[Deamidated]DE") == find_split("PEPTEDE"), (
-            "Q[Deamidated] and E variants must land in the same split"
-        )
+        assert find_split("PEPTQ[Deamidated]DE") == find_split(
+            "PEPTEDE"
+        ), "Q[Deamidated] and E variants must land in the same split"
 
     def test_all_three_normalizations_together(self, tmp_path):
         """A peptide with I, N[Deamidated], and Q[Deamidated] is grouped with
@@ -975,16 +977,17 @@ class TestCreateDatasetsIsobaricNormalization:
         test = _read_mgf(tmp_path / "out.test.mgf")
 
         all_seqs = set(_get_peptides(train + val + test))
-        assert "PEPTN[Deamidated]DE" in all_seqs, (
-            "Original N[Deamidated] sequence must be preserved in output"
-        )
+        assert (
+            "PEPTN[Deamidated]DE" in all_seqs
+        ), "Original N[Deamidated] sequence must be preserved in output"
         assert "PEPTDDE" in all_seqs
 
     def test_deamidation_with_existing_splits(self, tmp_path):
         """N[Deamidated]-form in new data routes to the split containing the D-form."""
         train_path = _write_mgf(
             tmp_path / "exist_train.mgf",
-            [("PEPTDDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+            [("PEPTDDE", [100.0], [1.0])]
+            + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
         )
         val_path = _write_mgf(
             tmp_path / "exist_val.mgf",
@@ -1017,8 +1020,8 @@ class TestCreateDatasetsIsobaricNormalization:
         val_seqs = set(_get_peptides(val))
         test_seqs = set(_get_peptides(test))
 
-        assert "PEPTN[Deamidated]DE" in train_seqs, (
-            "N[Deamidated]-form should follow D-form into train"
-        )
+        assert (
+            "PEPTN[Deamidated]DE" in train_seqs
+        ), "N[Deamidated]-form should follow D-form into train"
         assert "PEPTN[Deamidated]DE" not in val_seqs
         assert "PEPTN[Deamidated]DE" not in test_seqs

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -694,8 +694,8 @@ class TestCreateDatasetsExistingSplits:
             )
 
 
-class TestCreateDatasetsILNormalization:
-    """Tests for I/L normalization during splitting."""
+class TestCreateDatasetsIsobaricNormalization:
+    """Tests for isobaric normalization during splitting (I/L and deamidation)."""
 
     def test_il_variants_land_in_same_split(self, tmp_path):
         """Peptides differing only by I/L are placed in the same split."""
@@ -707,7 +707,7 @@ class TestCreateDatasetsILNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=True)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -724,7 +724,7 @@ class TestCreateDatasetsILNormalization:
         )
 
     def test_il_variants_counted_as_one_peptide(self, tmp_path):
-        """With normalize_il=True, I/L variants count as a single peptide."""
+        """With normalize_isobaric=True, I/L variants count as a single peptide."""
         # 10 I/L pairs + 80 unique = 90 sequences but only 80+10=90 canonical
         # peptides... actually each pair shares a canonical form, so 10 pairs
         # contribute 10 canonical peptides rather than 20.
@@ -737,7 +737,7 @@ class TestCreateDatasetsILNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=True)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -761,8 +761,8 @@ class TestCreateDatasetsILNormalization:
                 f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
             )
 
-    def test_normalize_il_false_treats_variants_independently(self, tmp_path):
-        """With normalize_il=False, I/L variants are treated as distinct peptides."""
+    def test_normalize_isobaric_false_treats_variants_independently(self, tmp_path):
+        """With normalize_isobaric=False, I/L variants are treated as distinct peptides."""
         # With a fixed random seed and enough peptides, I/L variants CAN end up
         # in different splits when normalization is off. We verify that the two
         # sequences are treated as independent (i.e. both appear in the output).
@@ -772,7 +772,7 @@ class TestCreateDatasetsILNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=False)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=False)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -786,14 +786,14 @@ class TestCreateDatasetsILNormalization:
         assert len(all_seqs) == len(spectra)
 
     def test_original_sequences_preserved_in_output(self, tmp_path):
-        """Output MGF files retain original sequences even when normalize_il=True."""
+        """Output MGF files retain original sequences even when normalize_isobaric=True."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=True)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -837,7 +837,7 @@ class TestCreateDatasetsILNormalization:
             mgf,
             output_root=output_root,
             existing_splits=existing,
-            normalize_il=True,
+            normalize_isobaric=True,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -854,14 +854,14 @@ class TestCreateDatasetsILNormalization:
         assert "PEPTIDE" not in test_seqs
 
     def test_il_normalization_default_is_true(self, tmp_path):
-        """normalize_il defaults to True (I/L variants placed in same split)."""
+        """normalize_isobaric defaults to True (I/L variants placed in same split)."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        # Call without normalize_il — should default to True.
+        # Call without normalize_isobaric — should default to True.
         create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -877,3 +877,154 @@ class TestCreateDatasetsILNormalization:
         assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
             "Default behavior must place I/L variants in the same split"
         )
+
+    def test_deamidated_n_and_d_land_in_same_split(self, tmp_path):
+        """N[Deamidated] and D variants of the same peptide land in the same split."""
+        spectra = [
+            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTDDE", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPT[N[Deamidated]]DE") == find_split("PEPTDDE"), (
+            "N[Deamidated] and D variants must land in the same split"
+        )
+
+    def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
+        """Q[Deamidated] and E variants of the same peptide land in the same split."""
+        spectra = [
+            ("PEPT[Q[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTEDE", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPT[Q[Deamidated]]DE") == find_split("PEPTEDE"), (
+            "Q[Deamidated] and E variants must land in the same split"
+        )
+
+    def test_all_three_normalizations_together(self, tmp_path):
+        """A peptide with I, N[Deamidated], and Q[Deamidated] is grouped with
+        its fully-canonical D/E/L equivalent."""
+        # IN[Deamidated]Q[Deamidated]K → LDEK after full canonicalization.
+        spectra = [
+            ("IN[Deamidated]Q[Deamidated]K", [100.0], [1.0]),
+            ("LDEK", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("IN[Deamidated]Q[Deamidated]K") == find_split("LDEK"), (
+            "Peptide with I, N[Deamidated], and Q[Deamidated] must land in "
+            "the same split as its canonical D/E/L form"
+        )
+
+    def test_deamidation_normalization_preserves_original_sequences(self, tmp_path):
+        """Output MGFs retain original sequences even with deamidation normalization."""
+        spectra = [
+            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTDDE", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        all_seqs = set(_get_peptides(train + val + test))
+        assert "PEPT[N[Deamidated]]DE" in all_seqs, (
+            "Original N[Deamidated] sequence must be preserved in output"
+        )
+        assert "PEPTDDE" in all_seqs
+
+    def test_deamidation_with_existing_splits(self, tmp_path):
+        """N[Deamidated]-form in new data routes to the split containing the D-form."""
+        train_path = _write_mgf(
+            tmp_path / "exist_train.mgf",
+            [("PEPTDDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+        )
+        val_path = _write_mgf(
+            tmp_path / "exist_val.mgf",
+            [(f"VA{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        test_path = _write_mgf(
+            tmp_path / "exist_test.mgf",
+            [(f"TE{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        existing = (train_path, val_path, test_path)
+
+        mgf = _write_mgf(
+            tmp_path / "new.mgf",
+            [("PEPT[N[Deamidated]]DE", [100.0], [1.0])]
+            + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        output_root = str(tmp_path / "out")
+
+        create_datasets(
+            mgf,
+            output_root=output_root,
+            existing_splits=existing,
+            normalize_isobaric=True,
+        )
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        train_seqs = set(_get_peptides(train))
+        val_seqs = set(_get_peptides(val))
+        test_seqs = set(_get_peptides(test))
+
+        assert "PEPT[N[Deamidated]]DE" in train_seqs, (
+            "N[Deamidated]-form should follow D-form into train"
+        )
+        assert "PEPT[N[Deamidated]]DE" not in val_seqs
+        assert "PEPT[N[Deamidated]]DE" not in test_seqs

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -692,3 +692,188 @@ class TestCreateDatasetsExistingSplits:
                 existing_splits=existing,
                 combine_with_existing=True,
             )
+
+
+class TestCreateDatasetsILNormalization:
+    """Tests for I/L normalization during splitting."""
+
+    def test_il_variants_land_in_same_split(self, tmp_path):
+        """Peptides differing only by I/L are placed in the same split."""
+        # PEPTIDE and PEPTLDE are I/L variants of each other.
+        # Add enough unrelated peptides to trigger real splitting.
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for split_name, split in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in split):
+                    return split_name
+            return None
+
+        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
+            "I/L variants must land in the same split"
+        )
+
+    def test_il_variants_counted_as_one_peptide(self, tmp_path):
+        """With normalize_il=True, I/L variants count as a single peptide."""
+        # 10 I/L pairs + 80 unique = 90 sequences but only 80+10=90 canonical
+        # peptides... actually each pair shares a canonical form, so 10 pairs
+        # contribute 10 canonical peptides rather than 20.
+        spectra = []
+        for i in range(10):
+            spectra.append((f"PEP{i}I", [100.0], [1.0]))  # with I
+            spectra.append((f"PEP{i}L", [100.0], [1.0]))  # same canonical
+        for i in range(80):
+            spectra.append((f"UNIQ{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        # Total spectra must be preserved.
+        assert len(train) + len(val) + len(test) == len(spectra)
+
+        # Each I/L pair must be in the same split.
+        for i in range(10):
+            i_seq = f"PEP{i}I"
+            l_seq = f"PEP{i}L"
+
+            def find_split(seq, tr=train, v=val, te=test):
+                for name, sp in [("train", tr), ("val", v), ("test", te)]:
+                    if any(s["params"]["seq"] == seq for s in sp):
+                        return name
+                return None
+
+            assert find_split(i_seq) == find_split(l_seq), (
+                f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
+            )
+
+    def test_normalize_il_false_treats_variants_independently(self, tmp_path):
+        """With normalize_il=False, I/L variants are treated as distinct peptides."""
+        # With a fixed random seed and enough peptides, I/L variants CAN end up
+        # in different splits when normalization is off. We verify that the two
+        # sequences are treated as independent (i.e. both appear in the output).
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=False)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        all_seqs = _get_peptides(train + val + test)
+        # Both sequences appear in the output regardless of normalization.
+        assert "PEPTIDE" in all_seqs
+        assert "PEPTLDE" in all_seqs
+        # Total spectra preserved.
+        assert len(all_seqs) == len(spectra)
+
+    def test_original_sequences_preserved_in_output(self, tmp_path):
+        """Output MGF files retain original sequences even when normalize_il=True."""
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        all_seqs = set(_get_peptides(train + val + test))
+        # Original sequences (not canonical) must appear in the output.
+        assert "PEPTIDE" in all_seqs
+        assert "PEPTLDE" in all_seqs
+        # The canonical form should NOT appear as a distinct entry
+        # (it was never an input sequence).
+        assert "PEPTLDE" in all_seqs  # L-only form is a real input sequence
+        # Make sure we didn't accidentally replace sequences in the output.
+        assert "PEPTIDE" in all_seqs  # I-form must still be present
+
+    def test_il_normalization_with_existing_splits(self, tmp_path):
+        """I/L variant in new data routes to the correct existing split."""
+        # Existing train split contains PEPTLDE (L-form).
+        train_path = _write_mgf(
+            tmp_path / "exist_train.mgf",
+            [("PEPTLDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+        )
+        val_path = _write_mgf(
+            tmp_path / "exist_val.mgf",
+            [(f"VA{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        test_path = _write_mgf(
+            tmp_path / "exist_test.mgf",
+            [(f"TE{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        existing = (train_path, val_path, test_path)
+
+        # New data has PEPTIDE (I-form), the I/L variant of PEPTLDE.
+        mgf = _write_mgf(
+            tmp_path / "new.mgf",
+            [("PEPTIDE", [100.0], [1.0])] + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        output_root = str(tmp_path / "out")
+
+        create_datasets(
+            mgf,
+            output_root=output_root,
+            existing_splits=existing,
+            normalize_il=True,
+        )
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        train_seqs = set(_get_peptides(train))
+        val_seqs = set(_get_peptides(val))
+        test_seqs = set(_get_peptides(test))
+
+        # PEPTIDE (I-form) must land in train alongside PEPTLDE (L-form).
+        assert "PEPTIDE" in train_seqs, "I-form should follow L-form into train"
+        assert "PEPTIDE" not in val_seqs
+        assert "PEPTIDE" not in test_seqs
+
+    def test_il_normalization_default_is_true(self, tmp_path):
+        """normalize_il defaults to True (I/L variants placed in same split)."""
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        # Call without normalize_il — should default to True.
+        create_datasets(mgf, output_root=output_root)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
+            "Default behavior must place I/L variants in the same split"
+        )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -802,14 +802,9 @@ class TestCreateDatasetsIsobaricNormalization:
         test = _read_mgf(tmp_path / "out.test.mgf")
 
         all_seqs = set(_get_peptides(train + val + test))
-        # Original sequences (not canonical) must appear in the output.
+        # Original sequences (not their canonical forms) must be preserved.
         assert "PEPTIDE" in all_seqs
         assert "PEPTLDE" in all_seqs
-        # The canonical form should NOT appear as a distinct entry
-        # (it was never an input sequence).
-        assert "PEPTLDE" in all_seqs  # L-only form is a real input sequence
-        # Make sure we didn't accidentally replace sequences in the output.
-        assert "PEPTIDE" in all_seqs  # I-form must still be present
 
     def test_il_normalization_with_existing_splits(self, tmp_path):
         """I/L variant in new data routes to the correct existing split."""
@@ -881,7 +876,7 @@ class TestCreateDatasetsIsobaricNormalization:
     def test_deamidated_n_and_d_land_in_same_split(self, tmp_path):
         """N[Deamidated] and D variants of the same peptide land in the same split."""
         spectra = [
-            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTN[Deamidated]DE", [100.0], [1.0]),
             ("PEPTDDE", [100.0], [1.0]),
         ]
         for i in range(28):
@@ -901,14 +896,14 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPT[N[Deamidated]]DE") == find_split("PEPTDDE"), (
+        assert find_split("PEPTN[Deamidated]DE") == find_split("PEPTDDE"), (
             "N[Deamidated] and D variants must land in the same split"
         )
 
     def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
         """Q[Deamidated] and E variants of the same peptide land in the same split."""
         spectra = [
-            ("PEPT[Q[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTQ[Deamidated]DE", [100.0], [1.0]),
             ("PEPTEDE", [100.0], [1.0]),
         ]
         for i in range(28):
@@ -928,7 +923,7 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPT[Q[Deamidated]]DE") == find_split("PEPTEDE"), (
+        assert find_split("PEPTQ[Deamidated]DE") == find_split("PEPTEDE"), (
             "Q[Deamidated] and E variants must land in the same split"
         )
 
@@ -965,7 +960,7 @@ class TestCreateDatasetsIsobaricNormalization:
     def test_deamidation_normalization_preserves_original_sequences(self, tmp_path):
         """Output MGFs retain original sequences even with deamidation normalization."""
         spectra = [
-            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTN[Deamidated]DE", [100.0], [1.0]),
             ("PEPTDDE", [100.0], [1.0]),
         ]
         for i in range(28):
@@ -980,7 +975,7 @@ class TestCreateDatasetsIsobaricNormalization:
         test = _read_mgf(tmp_path / "out.test.mgf")
 
         all_seqs = set(_get_peptides(train + val + test))
-        assert "PEPT[N[Deamidated]]DE" in all_seqs, (
+        assert "PEPTN[Deamidated]DE" in all_seqs, (
             "Original N[Deamidated] sequence must be preserved in output"
         )
         assert "PEPTDDE" in all_seqs
@@ -1003,7 +998,7 @@ class TestCreateDatasetsIsobaricNormalization:
 
         mgf = _write_mgf(
             tmp_path / "new.mgf",
-            [("PEPT[N[Deamidated]]DE", [100.0], [1.0])]
+            [("PEPTN[Deamidated]DE", [100.0], [1.0])]
             + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
         )
         output_root = str(tmp_path / "out")
@@ -1022,8 +1017,8 @@ class TestCreateDatasetsIsobaricNormalization:
         val_seqs = set(_get_peptides(val))
         test_seqs = set(_get_peptides(test))
 
-        assert "PEPT[N[Deamidated]]DE" in train_seqs, (
+        assert "PEPTN[Deamidated]DE" in train_seqs, (
             "N[Deamidated]-form should follow D-form into train"
         )
-        assert "PEPT[N[Deamidated]]DE" not in val_seqs
-        assert "PEPT[N[Deamidated]]DE" not in test_seqs
+        assert "PEPTN[Deamidated]DE" not in val_seqs
+        assert "PEPTN[Deamidated]DE" not in test_seqs

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -707,7 +707,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -724,7 +724,7 @@ class TestCreateDatasetsIsobaricNormalization:
         )
 
     def test_il_variants_counted_as_one_peptide(self, tmp_path):
-        """With normalize_isobaric=True, I/L variants count as a single peptide."""
+        """I/L variants count as a single peptide due to isobaric normalization."""
         # 10 I/L pairs + 80 unique = 90 sequences but only 80+10=90 canonical
         # peptides... actually each pair shares a canonical form, so 10 pairs
         # contribute 10 canonical peptides rather than 20.
@@ -737,7 +737,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -761,39 +761,41 @@ class TestCreateDatasetsIsobaricNormalization:
                 f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
             )
 
-    def test_normalize_isobaric_false_treats_variants_independently(self, tmp_path):
-        """With normalize_isobaric=False, I/L variants are treated as distinct peptides."""
-        # With a fixed random seed and enough peptides, I/L variants CAN end up
-        # in different splits when normalization is off. We verify that the two
-        # sequences are treated as independent (i.e. both appear in the output).
+    def test_isobaric_normalization_is_unconditional(self, tmp_path):
+        """Isobaric normalization is always applied; there is no opt-out."""
+        # Verify that PEPTIDE and PEPTLDE (I/L variants) always land in the
+        # same split regardless of how create_datasets is called.
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=False)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
         test = _read_mgf(tmp_path / "out.test.mgf")
 
-        all_seqs = _get_peptides(train + val + test)
-        # Both sequences appear in the output regardless of normalization.
-        assert "PEPTIDE" in all_seqs
-        assert "PEPTLDE" in all_seqs
-        # Total spectra preserved.
-        assert len(all_seqs) == len(spectra)
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPTIDE") == find_split("PEPTLDE")
+        # All spectra are preserved.
+        assert len(train) + len(val) + len(test) == len(spectra)
 
     def test_original_sequences_preserved_in_output(self, tmp_path):
-        """Output MGF files retain original sequences even when normalize_isobaric=True."""
+        """Output MGF files retain original sequences despite isobaric normalization."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -837,7 +839,6 @@ class TestCreateDatasetsIsobaricNormalization:
             mgf,
             output_root=output_root,
             existing_splits=existing,
-            normalize_isobaric=True,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -853,15 +854,14 @@ class TestCreateDatasetsIsobaricNormalization:
         assert "PEPTIDE" not in val_seqs
         assert "PEPTIDE" not in test_seqs
 
-    def test_il_normalization_default_is_true(self, tmp_path):
-        """normalize_isobaric defaults to True (I/L variants placed in same split)."""
+    def test_il_normalization_always_applied(self, tmp_path):
+        """I/L variants are always placed in the same split."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        # Call without normalize_isobaric — should default to True.
         create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -889,7 +889,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -916,7 +916,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -945,7 +945,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -973,7 +973,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -1012,7 +1012,6 @@ class TestCreateDatasetsIsobaricNormalization:
             mgf,
             output_root=output_root,
             existing_splits=existing,
-            normalize_isobaric=True,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -898,8 +898,12 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTN[Deamidated]DE") == find_split(
-            "PEPTDDE"
+        split_n = find_split("PEPTN[Deamidated]DE")
+        split_d = find_split("PEPTDDE")
+        assert split_n is not None, "PEPTN[Deamidated]DE not found in any split"
+        assert split_d is not None, "PEPTDDE not found in any split"
+        assert (
+            split_n == split_d
         ), "N[Deamidated] and D variants must land in the same split"
 
     def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
@@ -925,8 +929,12 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTQ[Deamidated]DE") == find_split(
-            "PEPTEDE"
+        split_q = find_split("PEPTQ[Deamidated]DE")
+        split_e = find_split("PEPTEDE")
+        assert split_q is not None, "PEPTQ[Deamidated]DE not found in any split"
+        assert split_e is not None, "PEPTEDE not found in any split"
+        assert (
+            split_q == split_e
         ), "Q[Deamidated] and E variants must land in the same split"
 
     def test_all_three_normalizations_together(self, tmp_path):
@@ -954,7 +962,13 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("IN[Deamidated]Q[Deamidated]K") == find_split("LDEK"), (
+        split_inqk = find_split("IN[Deamidated]Q[Deamidated]K")
+        split_ldek = find_split("LDEK")
+        assert (
+            split_inqk is not None
+        ), "IN[Deamidated]Q[Deamidated]K not found in any split"
+        assert split_ldek is not None, "LDEK not found in any split"
+        assert split_inqk == split_ldek, (
             "Peptide with I, N[Deamidated], and Q[Deamidated] must land in "
             "the same split as its canonical D/E/L form"
         )


### PR DESCRIPTION
## Summary

- `create_datasets` previously keyed peptides by their raw sequence string, so mass-equivalent residues could be assigned to different splits, causing train/test leakage.
- Adds a `_canonical()` helper that always maps all isobaric residue pairs to a single representative form before peptides are grouped for splitting:
  - **I -> L**: isoleucine and leucine have identical masses
  - **N[Deamidated] -> D**: deamidated asparagine is mass-identical to aspartic acid
  - **Q[Deamidated] -> E**: deamidated glutamine is mass-identical to glutamic acid
- Normalization is unconditional â€” there is no parameter to disable it, since there is no valid reason to skip it.
- The `existing_splits` routing path is also fixed: variants in new data are correctly recognized as belonging to the split that contains their canonical equivalent.
- Original sequences are preserved unchanged in the output MGF files.

## Test plan

**I/L normalization:**
- [x] `test_il_variants_land_in_same_split`
- [x] `test_il_variants_counted_as_one_peptide`
- [x] `test_isobaric_normalization_is_unconditional`
- [x] `test_original_sequences_preserved_in_output`
- [x] `test_il_normalization_with_existing_splits`
- [x] `test_il_normalization_always_applied`

**Deamidation normalization:**
- [x] `test_deamidated_n_and_d_land_in_same_split`
- [x] `test_deamidated_q_and_e_land_in_same_split`
- [x] `test_all_three_normalizations_together` â€” peptide with I, N[Deamidated], and Q[Deamidated] grouped with its LDEK equivalent
- [x] `test_deamidation_normalization_preserves_original_sequences`
- [x] `test_deamidation_with_existing_splits`

All 41 tests pass (30 pre-existing + 11 new).

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved peptide grouping during dataset splitting and sampling by treating equivalent isobaric forms consistently.
  * Isoleucine/leucine variants and deamidated asparagine/glutamine forms are now grouped with their corresponding canonical forms.
  * Original peptide sequences remain unchanged in generated spectra.
  * Existing split assignments are respected across equivalent peptide variants.

* **Documentation**
  * Added documentation describing canonical peptide grouping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->