### PR TITLE
Add mskb2proforma: MassIVE-KB to ProForma MGF converter

### DIFF
--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -42,7 +42,19 @@ def _canonical(seq: str) -> str:
     str
         Canonical peptide sequence.
     """
-    seq = seq.replace("I", "L")
+    # Replace I with L only at residue positions (bracket depth 0), so that
+    # uppercase I characters inside modification names are left untouched.
+    chars = []
+    depth = 0
+    for ch in seq:
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+        elif ch == "I" and depth == 0:
+            ch = "L"
+        chars.append(ch)
+    seq = "".join(chars)
     seq = seq.replace("N[Deamidated]", "D")
     seq = seq.replace("Q[Deamidated]", "E")
     return seq

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -17,31 +17,40 @@ from .types import Commands
 _WRITE_BUFFER_SIZE = 1000
 
 
-def _canonical(seq: str, normalize_il: bool) -> str:
+def _canonical(seq: str, normalize_isobaric: bool) -> str:
     """Return the canonical form of a peptide sequence.
 
-    When *normalize_il* is True, isoleucine (I) is replaced with leucine (L)
-    so that sequences that are indistinguishable by mass spectrometry are
-    treated as identical during splitting.
+    When *normalize_isobaric* is True, residues that are indistinguishable by
+    mass spectrometry are mapped to a single representative token:
+
+    * Isoleucine (I) → Leucine (L)  [identical mass]
+    * N[Deamidated] → D  [deamidation of Asn yields Asp; identical mass]
+    * Q[Deamidated] → E  [deamidation of Gln yields Glu; identical mass]
 
     Parameters
     ----------
     seq : str
-        Peptide sequence.
-    normalize_il : bool
-        If True, replace I with L.
+        Peptide sequence, optionally containing bracket-enclosed modifications
+        in the form ``AA[ModName]``.
+    normalize_isobaric : bool
+        If True, apply all isobaric substitutions listed above.
 
     Returns
     -------
     str
         Canonical peptide sequence.
     """
-    return seq.replace("I", "L") if normalize_il else seq
+    if not normalize_isobaric:
+        return seq
+    seq = seq.replace("I", "L")
+    seq = seq.replace("N[Deamidated]", "D")
+    seq = seq.replace("Q[Deamidated]", "E")
+    return seq
 
 
 def _collect_peptide_counts(
     mgf_files: tuple[PathLike, ...],
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], int]:
     """Pass 1: stream all input MGF files and count spectra per peptide.
 
@@ -76,7 +85,7 @@ def _collect_peptide_counts(
                     f"Missing 'seq' in spectrum params for spectrum "
                     f"{spectrum_index} in file {mgf_file}"
                 ) from exc
-            key = _canonical(seq, normalize_il)
+            key = _canonical(seq, normalize_isobaric)
             pep_counts[key] = pep_counts.get(key, 0) + 1
             file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
@@ -92,7 +101,7 @@ def _assign_splits(
     total_spectra: int,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     spectra_per_peptide: Optional[int],
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, str], dict[str, set[int]], dict[str, set[str]]]:
     """Compute per-peptide split assignments and sampling indices.
 
@@ -108,9 +117,10 @@ def _assign_splits(
         Paths to existing train/val/test MGF files, or None.
     spectra_per_peptide : int or None
         Maximum spectra to retain per peptide, or None.
-    normalize_il : bool, default=True
-        If True, isoleucine (I) is replaced with leucine (L) when comparing
-        peptide sequences, matching the behavior of ``_collect_peptide_counts``.
+    normalize_isobaric : bool, default=True
+        If True, isobaric residues are canonicalized when comparing peptide
+        sequences, matching the behavior of ``_collect_peptide_counts``.
+        See ``_canonical`` for the full set of substitutions applied.
 
     Returns
     -------
@@ -171,7 +181,7 @@ def _assign_splits(
                         f"existing split '{split_name}' from file "
                         f"'{split_path}'"
                     ) from exc
-                existing_peps[split_name].add(_canonical(seq, normalize_il))
+                existing_peps[split_name].add(_canonical(seq, normalize_isobaric))
             logging.info(
                 f"Existing {split_name}: "
                 f"{len(existing_peps[split_name])} peptide"
@@ -325,7 +335,7 @@ def _write_splits(
     spectra_per_peptide: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
     """Pass 2: stream spectra to output MGF files.
 
@@ -345,10 +355,10 @@ def _write_splits(
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
         If True, prepend existing split spectra to each output file.
-    normalize_il : bool, default=True
-        If True, isoleucine (I) is replaced with leucine (L) when looking up
-        each spectrum's split assignment. Original sequences are preserved in
-        the output MGF files.
+    normalize_isobaric : bool, default=True
+        If True, isobaric residues are canonicalized when looking up each
+        spectrum's split assignment. Original sequences are preserved in the
+        output MGF files. See ``_canonical`` for the substitutions applied.
 
     Returns
     -------
@@ -426,7 +436,7 @@ def _write_splits(
                 unit="PSM",
             ):
                 seq = spectrum["params"]["seq"]
-                key = _canonical(seq, normalize_il)
+                key = _canonical(seq, normalize_isobaric)
 
                 # Apply spectra_per_peptide filtering.
                 if spectra_per_peptide is not None:
@@ -457,7 +467,7 @@ def create_datasets(
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
-    normalize_il: bool = True,
+    normalize_isobaric: bool = True,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -467,12 +477,19 @@ def create_datasets(
     based on their associated peptide, ensuring no peptide-level leakage
     between splits.
 
-    Because mass spectrometry cannot distinguish isoleucine (I) from leucine
-    (L), peptides that differ only at I/L positions are indistinguishable and
-    should always be placed in the same split. By default (``normalize_il=True``)
-    the splitting key replaces I with L before grouping, so all I/L variants of
-    a peptide are treated as one entity. The original sequences are preserved
-    unchanged in the output MGF files.
+    Several pairs of residues are indistinguishable by mass spectrometry and
+    must always be placed in the same split to prevent leakage:
+
+    * Isoleucine (I) and leucine (L) have identical masses.
+    * Deamidated asparagine (N[Deamidated]) and aspartic acid (D) have
+      identical masses.
+    * Deamidated glutamine (Q[Deamidated]) and glutamic acid (E) have
+      identical masses.
+
+    By default (``normalize_isobaric=True``), each spectrum's peptide sequence
+    is mapped to a canonical form before the split assignment is looked up, so
+    all mass-equivalent variants are grouped together. The original sequences
+    are preserved unchanged in the output MGF files.
 
     Parameters
     ----------
@@ -501,11 +518,12 @@ def create_datasets(
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
-    normalize_il : bool, default=True
-        If True, isoleucine (I) is replaced with leucine (L) when grouping
-        peptides for splitting. This prevents train/test leakage between
-        peptides that are indistinguishable by mass spectrometry. Original
-        sequences are preserved in the output MGF files.
+    normalize_isobaric : bool, default=True
+        If True, mass-equivalent residues are canonicalized before peptides
+        are grouped for splitting, preventing train/test leakage between
+        sequences that are indistinguishable by mass spectrometry (I/L,
+        N[Deamidated]/D, Q[Deamidated]/E). Original sequences are preserved
+        in the output MGF files.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -539,14 +557,14 @@ def create_datasets(
 
     random.seed(random_seed)
 
-    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_il)
+    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_isobaric)
 
     pep_to_split, sampled_indices, existing_peps = _assign_splits(
         pep_counts,
         total_spectra,
         existing_splits,
         spectra_per_peptide,
-        normalize_il,
+        normalize_isobaric,
     )
 
     split_spectra_counts, split_pep_sets = _write_splits(
@@ -557,7 +575,7 @@ def create_datasets(
         spectra_per_peptide,
         existing_splits,
         combine_with_existing,
-        normalize_il,
+        normalize_isobaric,
     )
 
     # Log split summaries.

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -17,8 +17,31 @@ from .types import Commands
 _WRITE_BUFFER_SIZE = 1000
 
 
+def _canonical(seq: str, normalize_il: bool) -> str:
+    """Return the canonical form of a peptide sequence.
+
+    When *normalize_il* is True, isoleucine (I) is replaced with leucine (L)
+    so that sequences that are indistinguishable by mass spectrometry are
+    treated as identical during splitting.
+
+    Parameters
+    ----------
+    seq : str
+        Peptide sequence.
+    normalize_il : bool
+        If True, replace I with L.
+
+    Returns
+    -------
+    str
+        Canonical peptide sequence.
+    """
+    return seq.replace("I", "L") if normalize_il else seq
+
+
 def _collect_peptide_counts(
     mgf_files: tuple[PathLike, ...],
+    normalize_il: bool = True,
 ) -> tuple[dict[str, int], int]:
     """Pass 1: stream all input MGF files and count spectra per peptide.
 
@@ -30,7 +53,7 @@ def _collect_peptide_counts(
     Returns
     -------
     pep_counts : dict[str, int]
-        Mapping of peptide sequence to spectrum count.
+        Mapping of canonical peptide sequence to spectrum count.
     total_spectra : int
         Total number of spectra read across all files.
     """
@@ -53,7 +76,8 @@ def _collect_peptide_counts(
                     f"Missing 'seq' in spectrum params for spectrum "
                     f"{spectrum_index} in file {mgf_file}"
                 ) from exc
-            pep_counts[seq] = pep_counts.get(seq, 0) + 1
+            key = _canonical(seq, normalize_il)
+            pep_counts[key] = pep_counts.get(key, 0) + 1
             file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
         total_spectra += file_count
@@ -68,6 +92,7 @@ def _assign_splits(
     total_spectra: int,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     spectra_per_peptide: Optional[int],
+    normalize_il: bool = True,
 ) -> tuple[dict[str, str], dict[str, set[int]], dict[str, set[str]]]:
     """Compute per-peptide split assignments and sampling indices.
 
@@ -83,11 +108,15 @@ def _assign_splits(
         Paths to existing train/val/test MGF files, or None.
     spectra_per_peptide : int or None
         Maximum spectra to retain per peptide, or None.
+    normalize_il : bool, default=True
+        If True, isoleucine (I) is replaced with leucine (L) when comparing
+        peptide sequences, matching the behavior of ``_collect_peptide_counts``.
 
     Returns
     -------
     pep_to_split : dict[str, str]
-        Mapping of peptide sequence to split name ("train", "val", "test").
+        Mapping of canonical peptide sequence to split name
+        ("train", "val", "test").
     sampled_indices : dict[str, set[int]]
         For peptides that exceed spectra_per_peptide, the 0-based indices
         of spectra to retain. Empty dict if spectra_per_peptide is None.
@@ -142,7 +171,7 @@ def _assign_splits(
                         f"existing split '{split_name}' from file "
                         f"'{split_path}'"
                     ) from exc
-                existing_peps[split_name].add(seq)
+                existing_peps[split_name].add(_canonical(seq, normalize_il))
             logging.info(
                 f"Existing {split_name}: "
                 f"{len(existing_peps[split_name])} peptide"
@@ -296,6 +325,7 @@ def _write_splits(
     spectra_per_peptide: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
+    normalize_il: bool = True,
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
     """Pass 2: stream spectra to output MGF files.
 
@@ -315,6 +345,10 @@ def _write_splits(
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
         If True, prepend existing split spectra to each output file.
+    normalize_il : bool, default=True
+        If True, isoleucine (I) is replaced with leucine (L) when looking up
+        each spectrum's split assignment. Original sequences are preserved in
+        the output MGF files.
 
     Returns
     -------
@@ -392,18 +426,19 @@ def _write_splits(
                 unit="PSM",
             ):
                 seq = spectrum["params"]["seq"]
+                key = _canonical(seq, normalize_il)
 
                 # Apply spectra_per_peptide filtering.
                 if spectra_per_peptide is not None:
-                    idx = pep_counters.get(seq, 0)
-                    pep_counters[seq] = idx + 1
-                    if seq in sampled_indices:
-                        if idx not in sampled_indices[seq]:
+                    idx = pep_counters.get(key, 0)
+                    pep_counters[key] = idx + 1
+                    if key in sampled_indices:
+                        if idx not in sampled_indices[key]:
                             continue
-                    # If seq not in sampled_indices, count <= limit,
+                    # If key not in sampled_indices, count <= limit,
                     # so keep all.
 
-                split_name = pep_to_split.get(seq)
+                split_name = pep_to_split.get(key)
                 if split_name is not None:
                     write_spectrum(split_name, spectrum)
 
@@ -422,6 +457,7 @@ def create_datasets(
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
+    normalize_il: bool = True,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -430,6 +466,13 @@ def create_datasets(
     validation (10%), and test (10%) sets. Spectra are then assigned to splits
     based on their associated peptide, ensuring no peptide-level leakage
     between splits.
+
+    Because mass spectrometry cannot distinguish isoleucine (I) from leucine
+    (L), peptides that differ only at I/L positions are indistinguishable and
+    should always be placed in the same split. By default (``normalize_il=True``)
+    the splitting key replaces I with L before grouping, so all I/L variants of
+    a peptide are treated as one entity. The original sequences are preserved
+    unchanged in the output MGF files.
 
     Parameters
     ----------
@@ -458,6 +501,11 @@ def create_datasets(
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
+    normalize_il : bool, default=True
+        If True, isoleucine (I) is replaced with leucine (L) when grouping
+        peptides for splitting. This prevents train/test leakage between
+        peptides that are indistinguishable by mass spectrometry. Original
+        sequences are preserved in the output MGF files.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -491,13 +539,14 @@ def create_datasets(
 
     random.seed(random_seed)
 
-    pep_counts, total_spectra = _collect_peptide_counts(mgf_files)
+    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_il)
 
     pep_to_split, sampled_indices, existing_peps = _assign_splits(
         pep_counts,
         total_spectra,
         existing_splits,
         spectra_per_peptide,
+        normalize_il,
     )
 
     split_spectra_counts, split_pep_sets = _write_splits(
@@ -508,6 +557,7 @@ def create_datasets(
         spectra_per_peptide,
         existing_splits,
         combine_with_existing,
+        normalize_il,
     )
 
     # Log split summaries.

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -17,31 +17,31 @@ from .types import Commands
 _WRITE_BUFFER_SIZE = 1000
 
 
-def _canonical(seq: str, normalize_isobaric: bool) -> str:
+def _canonical(seq: str) -> str:
     """Return the canonical form of a peptide sequence.
 
-    When *normalize_isobaric* is True, residues that are indistinguishable by
-    mass spectrometry are mapped to a single representative token:
+    Residues that are indistinguishable by mass spectrometry are mapped to a
+    single representative token so that mass-equivalent variants are always
+    grouped together during splitting:
 
     * Isoleucine (I) → Leucine (L)  [identical mass]
     * N[Deamidated] → D  [deamidation of Asn yields Asp; identical mass]
     * Q[Deamidated] → E  [deamidation of Gln yields Glu; identical mass]
+
+    The canonical form is used only as a grouping key; original sequences are
+    preserved unchanged in the output MGF files.
 
     Parameters
     ----------
     seq : str
         Peptide sequence, optionally containing bracket-enclosed modifications
         in the form ``AA[ModName]``.
-    normalize_isobaric : bool
-        If True, apply all isobaric substitutions listed above.
 
     Returns
     -------
     str
         Canonical peptide sequence.
     """
-    if not normalize_isobaric:
-        return seq
     seq = seq.replace("I", "L")
     seq = seq.replace("N[Deamidated]", "D")
     seq = seq.replace("Q[Deamidated]", "E")
@@ -50,7 +50,6 @@ def _canonical(seq: str, normalize_isobaric: bool) -> str:
 
 def _collect_peptide_counts(
     mgf_files: tuple[PathLike, ...],
-    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], int]:
     """Pass 1: stream all input MGF files and count spectra per peptide.
 
@@ -85,7 +84,7 @@ def _collect_peptide_counts(
                     f"Missing 'seq' in spectrum params for spectrum "
                     f"{spectrum_index} in file {mgf_file}"
                 ) from exc
-            key = _canonical(seq, normalize_isobaric)
+            key = _canonical(seq)
             pep_counts[key] = pep_counts.get(key, 0) + 1
             file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
@@ -101,7 +100,6 @@ def _assign_splits(
     total_spectra: int,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     spectra_per_peptide: Optional[int],
-    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, str], dict[str, set[int]], dict[str, set[str]]]:
     """Compute per-peptide split assignments and sampling indices.
 
@@ -110,17 +108,13 @@ def _assign_splits(
     Parameters
     ----------
     pep_counts : dict[str, int]
-        Mapping of peptide sequence to spectrum count from pass 1.
+        Mapping of canonical peptide sequence to spectrum count from pass 1.
     total_spectra : int
         Total spectra across all input files.
     existing_splits : tuple of PathLike or None
         Paths to existing train/val/test MGF files, or None.
     spectra_per_peptide : int or None
         Maximum spectra to retain per peptide, or None.
-    normalize_isobaric : bool, default=True
-        If True, isobaric residues are canonicalized when comparing peptide
-        sequences, matching the behavior of ``_collect_peptide_counts``.
-        See ``_canonical`` for the full set of substitutions applied.
 
     Returns
     -------
@@ -131,8 +125,8 @@ def _assign_splits(
         For peptides that exceed spectra_per_peptide, the 0-based indices
         of spectra to retain. Empty dict if spectra_per_peptide is None.
     existing_peps : dict[str, set[str]]
-        Peptides already present in each existing split. Empty sets if
-        existing_splits is None.
+        Canonical peptides already present in each existing split. Empty sets
+        if existing_splits is None.
     """
     # Pre-compute which spectrum indices to keep for each peptide when
     # spectra_per_peptide is set.
@@ -181,7 +175,7 @@ def _assign_splits(
                         f"existing split '{split_name}' from file "
                         f"'{split_path}'"
                     ) from exc
-                existing_peps[split_name].add(_canonical(seq, normalize_isobaric))
+                existing_peps[split_name].add(_canonical(seq))
             logging.info(
                 f"Existing {split_name}: "
                 f"{len(existing_peps[split_name])} peptide"
@@ -335,7 +329,6 @@ def _write_splits(
     spectra_per_peptide: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
-    normalize_isobaric: bool = True,
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
     """Pass 2: stream spectra to output MGF files.
 
@@ -346,7 +339,7 @@ def _write_splits(
     output_root : str
         Root path for output files.
     pep_to_split : dict[str, str]
-        Mapping from peptide sequence to split name.
+        Mapping from canonical peptide sequence to split name.
     sampled_indices : dict[str, set[int]]
         Per-peptide sets of 0-based spectrum indices to retain.
     spectra_per_peptide : int or None
@@ -355,17 +348,13 @@ def _write_splits(
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
         If True, prepend existing split spectra to each output file.
-    normalize_isobaric : bool, default=True
-        If True, isobaric residues are canonicalized when looking up each
-        spectrum's split assignment. Original sequences are preserved in the
-        output MGF files. See ``_canonical`` for the substitutions applied.
 
     Returns
     -------
     split_spectra_counts : dict[str, int]
         Number of spectra written to each split.
     split_pep_sets : dict[str, set[str]]
-        Set of new peptides assigned to each split.
+        Set of new canonical peptides assigned to each split.
     """
     split_pep_sets = {
         split: {pep for pep, s in pep_to_split.items() if s == split}
@@ -436,7 +425,7 @@ def _write_splits(
                 unit="PSM",
             ):
                 seq = spectrum["params"]["seq"]
-                key = _canonical(seq, normalize_isobaric)
+                key = _canonical(seq)
 
                 # Apply spectra_per_peptide filtering.
                 if spectra_per_peptide is not None:
@@ -467,7 +456,6 @@ def create_datasets(
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
-    normalize_isobaric: bool = True,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -478,7 +466,7 @@ def create_datasets(
     between splits.
 
     Several pairs of residues are indistinguishable by mass spectrometry and
-    must always be placed in the same split to prevent leakage:
+    are always grouped together during splitting to prevent leakage:
 
     * Isoleucine (I) and leucine (L) have identical masses.
     * Deamidated asparagine (N[Deamidated]) and aspartic acid (D) have
@@ -486,10 +474,10 @@ def create_datasets(
     * Deamidated glutamine (Q[Deamidated]) and glutamic acid (E) have
       identical masses.
 
-    By default (``normalize_isobaric=True``), each spectrum's peptide sequence
-    is mapped to a canonical form before the split assignment is looked up, so
-    all mass-equivalent variants are grouped together. The original sequences
-    are preserved unchanged in the output MGF files.
+    Each spectrum's peptide sequence is mapped to a canonical form (see
+    ``_canonical``) before the split assignment is looked up, so all
+    mass-equivalent variants are always grouped together. The original
+    sequences are preserved unchanged in the output MGF files.
 
     Parameters
     ----------
@@ -518,12 +506,6 @@ def create_datasets(
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
-    normalize_isobaric : bool, default=True
-        If True, mass-equivalent residues are canonicalized before peptides
-        are grouped for splitting, preventing train/test leakage between
-        sequences that are indistinguishable by mass spectrometry (I/L,
-        N[Deamidated]/D, Q[Deamidated]/E). Original sequences are preserved
-        in the output MGF files.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -557,14 +539,13 @@ def create_datasets(
 
     random.seed(random_seed)
 
-    pep_counts, total_spectra = _collect_peptide_counts(mgf_files, normalize_isobaric)
+    pep_counts, total_spectra = _collect_peptide_counts(mgf_files)
 
     pep_to_split, sampled_indices, existing_peps = _assign_splits(
         pep_counts,
         total_spectra,
         existing_splits,
         spectra_per_peptide,
-        normalize_isobaric,
     )
 
     split_spectra_counts, split_pep_sets = _write_splits(
@@ -575,7 +556,6 @@ def create_datasets(
         spectra_per_peptide,
         existing_splits,
         combine_with_existing,
-        normalize_isobaric,
     )
 
     # Log split summaries.

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -14,11 +14,11 @@ from .types import Commands
 
 # Named N-terminal modifications keyed by their summed mass in daltons,
 # rounded to 3 decimal places.  Entries with a string value starting with
-# "+" or "-" are written as numeric ProForma tokens (e.g. "[+25.980265]-");
+# "+" or "-" are written as numeric ProForma tokens (e.g. "[+25.979265]-");
 # all other entries are written as named tokens (e.g. "[Acetyl]-").
 _NTERM_NAMES: dict[float, str] = {
     -17.027: "Ammonia-loss",
-    25.979: "+25.980265",  # Carbamyl (+43.006) + Ammonia-loss (-17.027)
+    25.979: "+25.979265",  # Carbamyl (+43.006) + Ammonia-loss (-17.027)
     42.011: "Acetyl",
     43.006: "Carbamyl",
 }
@@ -174,11 +174,15 @@ def convert(
                 n_skipped += 1
         return {**spectrum, "params": params}
 
-    with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
+    with pyteomics.mgf.read(
+        str(input_file), use_index=False, use_header=False
+    ) as reader:
+        header = reader.header
         spectra = tqdm.tqdm(reader, desc="Converting spectra", unit="spectrum")
         pyteomics.mgf.write(
             (_convert_spectrum(s) for s in spectra),
             output=str(output_file),
+            header=header,
         )
 
     logging.info("Converted %d spectra", n_converted)

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -1,0 +1,198 @@
+"""Convert MassIVE-KB annotated MGF files to ProForma sequence notation."""
+
+import logging
+import pathlib
+import re
+from os import PathLike
+
+import fire
+import pyteomics.mgf
+import tqdm
+
+from . import configure_logging
+from .types import Commands
+
+# Named N-terminal modifications keyed by their summed mass in daltons,
+# rounded to 3 decimal places.  Entries with a string value starting with
+# "+" or "-" are written as numeric ProForma tokens (e.g. "[+25.980265]-");
+# all other entries are written as named tokens (e.g. "[Acetyl]-").
+_NTERM_NAMES: dict[float, str] = {
+    -17.027: "Ammonia-loss",
+    25.979: "+25.980265",   # Carbamyl (+43.006) + Ammonia-loss (-17.027)
+    42.011: "Acetyl",
+    43.006: "Carbamyl",
+}
+
+# Named per-residue modifications.  Key is the MassIVE-KB token
+# "AA+mass"; value is the ProForma token.
+_RESIDUE_NAMES: dict[str, str] = {
+    "C+57.021": "C[Carbamidomethyl]",
+    "M+15.995": "M[Oxidation]",
+    "N+0.984": "N[Deamidated]",
+    "Q+0.984": "Q[Deamidated]",
+    "S+79.966": "S[Phospho]",
+    "T+79.966": "T[Phospho]",
+    "Y+79.966": "Y[Phospho]",
+}
+
+# Matches one or more leading signed mass shifts before the first residue.
+_LEADING_SHIFTS_RE = re.compile(r"^((?:[+-]\d+(?:\.\d+)?)+)(?=[A-Z])")
+
+# Extracts individual signed mass shifts from a string.
+_SHIFT_RE = re.compile(r"[+-]\d+(?:\.\d+)?")
+
+# Splits a sequence string before each uppercase letter (after position 0).
+_RESIDUE_SPLIT_RE = re.compile(r"(?<=.)(?=[A-Z])")
+
+# Matches a single-residue token with an attached signed mass shift.
+_RESIDUE_MOD_RE = re.compile(r"^([A-Z])([+-]\d+(?:\.\d+)?)$")
+
+
+def _convert_seq(seq: str) -> str:
+    """Convert a single MassIVE-KB peptide sequence string to ProForma.
+
+    Handles N-terminal modifications (including multiple stacked shifts,
+    which are summed into a single token), per-residue named modifications,
+    and per-residue unnamed modifications (formatted as ``AA[+mass]``).
+
+    Parameters
+    ----------
+    seq : str
+        Peptide sequence in MassIVE-KB format, e.g.
+        ``"+229.163+42.011AC+57.021GANHTLVLDSQK+229.163"``.
+
+    Returns
+    -------
+    str
+        Peptide sequence in ProForma format, e.g.
+        ``"[+271.174]-AC[Carbamidomethyl]GANHTLVLDSQK[+229.163]"``.
+    """
+    nterm = ""
+
+    # Extract and convert leading N-terminal modification(s).
+    m = _LEADING_SHIFTS_RE.match(seq)
+    if m:
+        nterm_str = m.group(1)
+        seq = seq[len(nterm_str):]
+        total = round(sum(float(s) for s in _SHIFT_RE.findall(nterm_str)), 3)
+        if total in _NTERM_NAMES:
+            label = _NTERM_NAMES[total]
+        elif total >= 0:
+            label = f"+{total:.3f}"
+        else:
+            label = f"{total:.3f}"
+        nterm = f"[{label}]-"
+
+    # Split into per-residue tokens and convert each one.
+    out_tokens = []
+    for token in _RESIDUE_SPLIT_RE.split(seq):
+        if token in _RESIDUE_NAMES:
+            out_tokens.append(_RESIDUE_NAMES[token])
+        else:
+            rm = _RESIDUE_MOD_RE.match(token)
+            if rm:
+                aa, mass = rm.group(1), rm.group(2)
+                out_tokens.append(f"{aa}[{mass}]")
+            else:
+                out_tokens.append(token)
+
+    return nterm + "".join(out_tokens)
+
+
+def convert(
+    input_file: PathLike,
+    output_file: PathLike,
+    overwrite: bool = False,
+) -> None:
+    """Convert a MassIVE-KB annotated MGF file to ProForma sequence notation.
+
+    Streams the input MGF file, rewrites the ``SEQ`` field of every spectrum
+    from the MassIVE-KB modification format to ProForma, and writes the result
+    to *output_file*.  All other spectrum fields are passed through unchanged.
+
+    The following conversions are applied:
+
+    *N-terminal modifications* — One or more leading signed mass shifts (e.g.
+    ``+229.163+42.011``) are summed into a single ProForma N-terminal token.
+    Common named modifications (Acetyl, Carbamyl, Ammonia-loss) are written
+    using their ProForma names; all others use the numeric form
+    ``[+mass]-``.
+
+    *Per-residue modifications* — Common named modifications are written using
+    their ProForma names (e.g. ``C+57.021`` → ``C[Carbamidomethyl]``,
+    ``S+79.966`` → ``S[Phospho]``); all others use the numeric form
+    ``AA[+mass]``.
+
+    Parameters
+    ----------
+    input_file : PathLike
+        Path to the input MassIVE-KB MGF file.
+    output_file : PathLike
+        Path for the converted output MGF file.  Must differ from
+        *input_file*.
+    overwrite : bool, default False
+        If False, raise an error when *output_file* already exists.
+    """
+    input_file = pathlib.Path(input_file)
+    output_file = pathlib.Path(output_file)
+
+    if input_file.resolve() == output_file.resolve():
+        raise ValueError(
+            "input_file and output_file must be different paths; "
+            "overwriting the input in-place is not supported."
+        )
+
+    if not overwrite and output_file.exists():
+        raise FileExistsError(
+            f"Output file already exists: {output_file}. "
+            "Use --overwrite to overwrite."
+        )
+
+    configure_logging(output_file.with_suffix(".log"))
+    logging.info("Converting %s -> %s", input_file, output_file)
+
+    n_converted = 0
+    n_skipped = 0
+
+    def _convert_spectrum(spectrum: dict) -> dict:
+        nonlocal n_converted, n_skipped
+        params = dict(spectrum["params"])
+        if "seq" in params:
+            original = params["seq"]
+            try:
+                params["seq"] = _convert_seq(original)
+                n_converted += 1
+            except Exception as exc:
+                logging.warning(
+                    "Could not convert sequence %r: %s — keeping original",
+                    original,
+                    exc,
+                )
+                n_skipped += 1
+        return {**spectrum, "params": params}
+
+    with pyteomics.mgf.read(str(input_file), use_index=False) as reader:
+        spectra = tqdm.tqdm(reader, desc="Converting spectra", unit="spectrum")
+        pyteomics.mgf.write(
+            (_convert_spectrum(s) for s in spectra),
+            output=str(output_file),
+        )
+
+    logging.info("Converted %d spectra", n_converted)
+    if n_skipped:
+        logging.warning(
+            "Skipped conversion for %d spectra (original SEQ retained)",
+            n_skipped,
+        )
+
+
+COMMANDS: Commands = convert
+
+
+def main() -> None:
+    """CLI entry point for mskb2proforma."""
+    fire.Fire(COMMANDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -18,7 +18,7 @@ from .types import Commands
 # all other entries are written as named tokens (e.g. "[Acetyl]-").
 _NTERM_NAMES: dict[float, str] = {
     -17.027: "Ammonia-loss",
-    25.979: "+25.980265",   # Carbamyl (+43.006) + Ammonia-loss (-17.027)
+    25.979: "+25.980265",  # Carbamyl (+43.006) + Ammonia-loss (-17.027)
     42.011: "Acetyl",
     43.006: "Carbamyl",
 }
@@ -73,15 +73,18 @@ def _convert_seq(seq: str) -> str:
     m = _LEADING_SHIFTS_RE.match(seq)
     if m:
         nterm_str = m.group(1)
-        seq = seq[len(nterm_str):]
+        seq = seq[len(nterm_str) :]
         total = round(sum(float(s) for s in _SHIFT_RE.findall(nterm_str)), 3)
-        if total in _NTERM_NAMES:
-            label = _NTERM_NAMES[total]
-        elif total >= 0:
-            label = f"+{total:.3f}"
+        # Canonicalize -0.0 → 0.0; a zero net shift needs no N-terminal token.
+        total = total + 0.0
+        if total == 0.0:
+            pass  # net shift is zero — no N-terminal modification token needed
+        elif total in _NTERM_NAMES:
+            nterm = f"[{_NTERM_NAMES[total]}]-"
+        elif total > 0:
+            nterm = f"[+{total:.3f}]-"
         else:
-            label = f"{total:.3f}"
-        nterm = f"[{label}]-"
+            nterm = f"[{total:.3f}]-"
 
     # Split into per-residue tokens and convert each one.
     out_tokens = []

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -719,9 +719,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return split_name
             return None
 
-        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
-            "I/L variants must land in the same split"
-        )
+        assert find_split("PEPTIDE") == find_split(
+            "PEPTLDE"
+        ), "I/L variants must land in the same split"
 
     def test_il_variants_counted_as_one_peptide(self, tmp_path):
         """I/L variants count as a single peptide due to isobaric normalization."""
@@ -757,9 +757,9 @@ class TestCreateDatasetsIsobaricNormalization:
                         return name
                 return None
 
-            assert find_split(i_seq) == find_split(l_seq), (
-                f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
-            )
+            assert find_split(i_seq) == find_split(
+                l_seq
+            ), f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
 
     def test_isobaric_normalization_is_unconditional(self, tmp_path):
         """Isobaric normalization is always applied; there is no opt-out."""
@@ -811,7 +811,8 @@ class TestCreateDatasetsIsobaricNormalization:
         # Existing train split contains PEPTLDE (L-form).
         train_path = _write_mgf(
             tmp_path / "exist_train.mgf",
-            [("PEPTLDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+            [("PEPTLDE", [100.0], [1.0])]
+            + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
         )
         val_path = _write_mgf(
             tmp_path / "exist_val.mgf",
@@ -826,7 +827,8 @@ class TestCreateDatasetsIsobaricNormalization:
         # New data has PEPTIDE (I-form), the I/L variant of PEPTLDE.
         mgf = _write_mgf(
             tmp_path / "new.mgf",
-            [("PEPTIDE", [100.0], [1.0])] + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
+            [("PEPTIDE", [100.0], [1.0])]
+            + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
         )
         output_root = str(tmp_path / "out")
 
@@ -869,9 +871,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
-            "Default behavior must place I/L variants in the same split"
-        )
+        assert find_split("PEPTIDE") == find_split(
+            "PEPTLDE"
+        ), "Default behavior must place I/L variants in the same split"
 
     def test_deamidated_n_and_d_land_in_same_split(self, tmp_path):
         """N[Deamidated] and D variants of the same peptide land in the same split."""
@@ -896,9 +898,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTN[Deamidated]DE") == find_split("PEPTDDE"), (
-            "N[Deamidated] and D variants must land in the same split"
-        )
+        assert find_split("PEPTN[Deamidated]DE") == find_split(
+            "PEPTDDE"
+        ), "N[Deamidated] and D variants must land in the same split"
 
     def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
         """Q[Deamidated] and E variants of the same peptide land in the same split."""
@@ -923,9 +925,9 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTQ[Deamidated]DE") == find_split("PEPTEDE"), (
-            "Q[Deamidated] and E variants must land in the same split"
-        )
+        assert find_split("PEPTQ[Deamidated]DE") == find_split(
+            "PEPTEDE"
+        ), "Q[Deamidated] and E variants must land in the same split"
 
     def test_all_three_normalizations_together(self, tmp_path):
         """A peptide with I, N[Deamidated], and Q[Deamidated] is grouped with
@@ -975,16 +977,17 @@ class TestCreateDatasetsIsobaricNormalization:
         test = _read_mgf(tmp_path / "out.test.mgf")
 
         all_seqs = set(_get_peptides(train + val + test))
-        assert "PEPTN[Deamidated]DE" in all_seqs, (
-            "Original N[Deamidated] sequence must be preserved in output"
-        )
+        assert (
+            "PEPTN[Deamidated]DE" in all_seqs
+        ), "Original N[Deamidated] sequence must be preserved in output"
         assert "PEPTDDE" in all_seqs
 
     def test_deamidation_with_existing_splits(self, tmp_path):
         """N[Deamidated]-form in new data routes to the split containing the D-form."""
         train_path = _write_mgf(
             tmp_path / "exist_train.mgf",
-            [("PEPTDDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+            [("PEPTDDE", [100.0], [1.0])]
+            + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
         )
         val_path = _write_mgf(
             tmp_path / "exist_val.mgf",
@@ -1017,8 +1020,8 @@ class TestCreateDatasetsIsobaricNormalization:
         val_seqs = set(_get_peptides(val))
         test_seqs = set(_get_peptides(test))
 
-        assert "PEPTN[Deamidated]DE" in train_seqs, (
-            "N[Deamidated]-form should follow D-form into train"
-        )
+        assert (
+            "PEPTN[Deamidated]DE" in train_seqs
+        ), "N[Deamidated]-form should follow D-form into train"
         assert "PEPTN[Deamidated]DE" not in val_seqs
         assert "PEPTN[Deamidated]DE" not in test_seqs

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -694,8 +694,8 @@ class TestCreateDatasetsExistingSplits:
             )
 
 
-class TestCreateDatasetsILNormalization:
-    """Tests for I/L normalization during splitting."""
+class TestCreateDatasetsIsobaricNormalization:
+    """Tests for isobaric normalization during splitting (I/L and deamidation)."""
 
     def test_il_variants_land_in_same_split(self, tmp_path):
         """Peptides differing only by I/L are placed in the same split."""
@@ -707,7 +707,7 @@ class TestCreateDatasetsILNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=True)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -724,7 +724,7 @@ class TestCreateDatasetsILNormalization:
         )
 
     def test_il_variants_counted_as_one_peptide(self, tmp_path):
-        """With normalize_il=True, I/L variants count as a single peptide."""
+        """With normalize_isobaric=True, I/L variants count as a single peptide."""
         # 10 I/L pairs + 80 unique = 90 sequences but only 80+10=90 canonical
         # peptides... actually each pair shares a canonical form, so 10 pairs
         # contribute 10 canonical peptides rather than 20.
@@ -737,7 +737,7 @@ class TestCreateDatasetsILNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=True)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -761,8 +761,8 @@ class TestCreateDatasetsILNormalization:
                 f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
             )
 
-    def test_normalize_il_false_treats_variants_independently(self, tmp_path):
-        """With normalize_il=False, I/L variants are treated as distinct peptides."""
+    def test_normalize_isobaric_false_treats_variants_independently(self, tmp_path):
+        """With normalize_isobaric=False, I/L variants are treated as distinct peptides."""
         # With a fixed random seed and enough peptides, I/L variants CAN end up
         # in different splits when normalization is off. We verify that the two
         # sequences are treated as independent (i.e. both appear in the output).
@@ -772,7 +772,7 @@ class TestCreateDatasetsILNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=False)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=False)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -786,14 +786,14 @@ class TestCreateDatasetsILNormalization:
         assert len(all_seqs) == len(spectra)
 
     def test_original_sequences_preserved_in_output(self, tmp_path):
-        """Output MGF files retain original sequences even when normalize_il=True."""
+        """Output MGF files retain original sequences even when normalize_isobaric=True."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_il=True)
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -837,7 +837,7 @@ class TestCreateDatasetsILNormalization:
             mgf,
             output_root=output_root,
             existing_splits=existing,
-            normalize_il=True,
+            normalize_isobaric=True,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -854,14 +854,14 @@ class TestCreateDatasetsILNormalization:
         assert "PEPTIDE" not in test_seqs
 
     def test_il_normalization_default_is_true(self, tmp_path):
-        """normalize_il defaults to True (I/L variants placed in same split)."""
+        """normalize_isobaric defaults to True (I/L variants placed in same split)."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        # Call without normalize_il — should default to True.
+        # Call without normalize_isobaric — should default to True.
         create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -877,3 +877,154 @@ class TestCreateDatasetsILNormalization:
         assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
             "Default behavior must place I/L variants in the same split"
         )
+
+    def test_deamidated_n_and_d_land_in_same_split(self, tmp_path):
+        """N[Deamidated] and D variants of the same peptide land in the same split."""
+        spectra = [
+            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTDDE", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPT[N[Deamidated]]DE") == find_split("PEPTDDE"), (
+            "N[Deamidated] and D variants must land in the same split"
+        )
+
+    def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
+        """Q[Deamidated] and E variants of the same peptide land in the same split."""
+        spectra = [
+            ("PEPT[Q[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTEDE", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPT[Q[Deamidated]]DE") == find_split("PEPTEDE"), (
+            "Q[Deamidated] and E variants must land in the same split"
+        )
+
+    def test_all_three_normalizations_together(self, tmp_path):
+        """A peptide with I, N[Deamidated], and Q[Deamidated] is grouped with
+        its fully-canonical D/E/L equivalent."""
+        # IN[Deamidated]Q[Deamidated]K → LDEK after full canonicalization.
+        spectra = [
+            ("IN[Deamidated]Q[Deamidated]K", [100.0], [1.0]),
+            ("LDEK", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("IN[Deamidated]Q[Deamidated]K") == find_split("LDEK"), (
+            "Peptide with I, N[Deamidated], and Q[Deamidated] must land in "
+            "the same split as its canonical D/E/L form"
+        )
+
+    def test_deamidation_normalization_preserves_original_sequences(self, tmp_path):
+        """Output MGFs retain original sequences even with deamidation normalization."""
+        spectra = [
+            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTDDE", [100.0], [1.0]),
+        ]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        all_seqs = set(_get_peptides(train + val + test))
+        assert "PEPT[N[Deamidated]]DE" in all_seqs, (
+            "Original N[Deamidated] sequence must be preserved in output"
+        )
+        assert "PEPTDDE" in all_seqs
+
+    def test_deamidation_with_existing_splits(self, tmp_path):
+        """N[Deamidated]-form in new data routes to the split containing the D-form."""
+        train_path = _write_mgf(
+            tmp_path / "exist_train.mgf",
+            [("PEPTDDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+        )
+        val_path = _write_mgf(
+            tmp_path / "exist_val.mgf",
+            [(f"VA{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        test_path = _write_mgf(
+            tmp_path / "exist_test.mgf",
+            [(f"TE{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        existing = (train_path, val_path, test_path)
+
+        mgf = _write_mgf(
+            tmp_path / "new.mgf",
+            [("PEPT[N[Deamidated]]DE", [100.0], [1.0])]
+            + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        output_root = str(tmp_path / "out")
+
+        create_datasets(
+            mgf,
+            output_root=output_root,
+            existing_splits=existing,
+            normalize_isobaric=True,
+        )
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        train_seqs = set(_get_peptides(train))
+        val_seqs = set(_get_peptides(val))
+        test_seqs = set(_get_peptides(test))
+
+        assert "PEPT[N[Deamidated]]DE" in train_seqs, (
+            "N[Deamidated]-form should follow D-form into train"
+        )
+        assert "PEPT[N[Deamidated]]DE" not in val_seqs
+        assert "PEPT[N[Deamidated]]DE" not in test_seqs

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -692,3 +692,188 @@ class TestCreateDatasetsExistingSplits:
                 existing_splits=existing,
                 combine_with_existing=True,
             )
+
+
+class TestCreateDatasetsILNormalization:
+    """Tests for I/L normalization during splitting."""
+
+    def test_il_variants_land_in_same_split(self, tmp_path):
+        """Peptides differing only by I/L are placed in the same split."""
+        # PEPTIDE and PEPTLDE are I/L variants of each other.
+        # Add enough unrelated peptides to trigger real splitting.
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for split_name, split in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in split):
+                    return split_name
+            return None
+
+        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
+            "I/L variants must land in the same split"
+        )
+
+    def test_il_variants_counted_as_one_peptide(self, tmp_path):
+        """With normalize_il=True, I/L variants count as a single peptide."""
+        # 10 I/L pairs + 80 unique = 90 sequences but only 80+10=90 canonical
+        # peptides... actually each pair shares a canonical form, so 10 pairs
+        # contribute 10 canonical peptides rather than 20.
+        spectra = []
+        for i in range(10):
+            spectra.append((f"PEP{i}I", [100.0], [1.0]))  # with I
+            spectra.append((f"PEP{i}L", [100.0], [1.0]))  # same canonical
+        for i in range(80):
+            spectra.append((f"UNIQ{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        # Total spectra must be preserved.
+        assert len(train) + len(val) + len(test) == len(spectra)
+
+        # Each I/L pair must be in the same split.
+        for i in range(10):
+            i_seq = f"PEP{i}I"
+            l_seq = f"PEP{i}L"
+
+            def find_split(seq, tr=train, v=val, te=test):
+                for name, sp in [("train", tr), ("val", v), ("test", te)]:
+                    if any(s["params"]["seq"] == seq for s in sp):
+                        return name
+                return None
+
+            assert find_split(i_seq) == find_split(l_seq), (
+                f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
+            )
+
+    def test_normalize_il_false_treats_variants_independently(self, tmp_path):
+        """With normalize_il=False, I/L variants are treated as distinct peptides."""
+        # With a fixed random seed and enough peptides, I/L variants CAN end up
+        # in different splits when normalization is off. We verify that the two
+        # sequences are treated as independent (i.e. both appear in the output).
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=False)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        all_seqs = _get_peptides(train + val + test)
+        # Both sequences appear in the output regardless of normalization.
+        assert "PEPTIDE" in all_seqs
+        assert "PEPTLDE" in all_seqs
+        # Total spectra preserved.
+        assert len(all_seqs) == len(spectra)
+
+    def test_original_sequences_preserved_in_output(self, tmp_path):
+        """Output MGF files retain original sequences even when normalize_il=True."""
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        create_datasets(mgf, output_root=output_root, normalize_il=True)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        all_seqs = set(_get_peptides(train + val + test))
+        # Original sequences (not canonical) must appear in the output.
+        assert "PEPTIDE" in all_seqs
+        assert "PEPTLDE" in all_seqs
+        # The canonical form should NOT appear as a distinct entry
+        # (it was never an input sequence).
+        assert "PEPTLDE" in all_seqs  # L-only form is a real input sequence
+        # Make sure we didn't accidentally replace sequences in the output.
+        assert "PEPTIDE" in all_seqs  # I-form must still be present
+
+    def test_il_normalization_with_existing_splits(self, tmp_path):
+        """I/L variant in new data routes to the correct existing split."""
+        # Existing train split contains PEPTLDE (L-form).
+        train_path = _write_mgf(
+            tmp_path / "exist_train.mgf",
+            [("PEPTLDE", [100.0], [1.0])] + [(f"TR{i}", [100.0], [1.0]) for i in range(7)],
+        )
+        val_path = _write_mgf(
+            tmp_path / "exist_val.mgf",
+            [(f"VA{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        test_path = _write_mgf(
+            tmp_path / "exist_test.mgf",
+            [(f"TE{i}", [100.0], [1.0]) for i in range(1)],
+        )
+        existing = (train_path, val_path, test_path)
+
+        # New data has PEPTIDE (I-form), the I/L variant of PEPTLDE.
+        mgf = _write_mgf(
+            tmp_path / "new.mgf",
+            [("PEPTIDE", [100.0], [1.0])] + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        output_root = str(tmp_path / "out")
+
+        create_datasets(
+            mgf,
+            output_root=output_root,
+            existing_splits=existing,
+            normalize_il=True,
+        )
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        train_seqs = set(_get_peptides(train))
+        val_seqs = set(_get_peptides(val))
+        test_seqs = set(_get_peptides(test))
+
+        # PEPTIDE (I-form) must land in train alongside PEPTLDE (L-form).
+        assert "PEPTIDE" in train_seqs, "I-form should follow L-form into train"
+        assert "PEPTIDE" not in val_seqs
+        assert "PEPTIDE" not in test_seqs
+
+    def test_il_normalization_default_is_true(self, tmp_path):
+        """normalize_il defaults to True (I/L variants placed in same split)."""
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        for i in range(28):
+            spectra.append((f"OTHER{i}", [100.0], [1.0]))
+        mgf = _write_mgf(tmp_path / "input.mgf", spectra)
+        output_root = str(tmp_path / "out")
+
+        # Call without normalize_il — should default to True.
+        create_datasets(mgf, output_root=output_root)
+
+        train = _read_mgf(tmp_path / "out.train.mgf")
+        val = _read_mgf(tmp_path / "out.val.mgf")
+        test = _read_mgf(tmp_path / "out.test.mgf")
+
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPTIDE") == find_split("PEPTLDE"), (
+            "Default behavior must place I/L variants in the same split"
+        )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -802,14 +802,9 @@ class TestCreateDatasetsIsobaricNormalization:
         test = _read_mgf(tmp_path / "out.test.mgf")
 
         all_seqs = set(_get_peptides(train + val + test))
-        # Original sequences (not canonical) must appear in the output.
+        # Original sequences (not their canonical forms) must be preserved.
         assert "PEPTIDE" in all_seqs
         assert "PEPTLDE" in all_seqs
-        # The canonical form should NOT appear as a distinct entry
-        # (it was never an input sequence).
-        assert "PEPTLDE" in all_seqs  # L-only form is a real input sequence
-        # Make sure we didn't accidentally replace sequences in the output.
-        assert "PEPTIDE" in all_seqs  # I-form must still be present
 
     def test_il_normalization_with_existing_splits(self, tmp_path):
         """I/L variant in new data routes to the correct existing split."""
@@ -881,7 +876,7 @@ class TestCreateDatasetsIsobaricNormalization:
     def test_deamidated_n_and_d_land_in_same_split(self, tmp_path):
         """N[Deamidated] and D variants of the same peptide land in the same split."""
         spectra = [
-            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTN[Deamidated]DE", [100.0], [1.0]),
             ("PEPTDDE", [100.0], [1.0]),
         ]
         for i in range(28):
@@ -901,14 +896,14 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPT[N[Deamidated]]DE") == find_split("PEPTDDE"), (
+        assert find_split("PEPTN[Deamidated]DE") == find_split("PEPTDDE"), (
             "N[Deamidated] and D variants must land in the same split"
         )
 
     def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
         """Q[Deamidated] and E variants of the same peptide land in the same split."""
         spectra = [
-            ("PEPT[Q[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTQ[Deamidated]DE", [100.0], [1.0]),
             ("PEPTEDE", [100.0], [1.0]),
         ]
         for i in range(28):
@@ -928,7 +923,7 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPT[Q[Deamidated]]DE") == find_split("PEPTEDE"), (
+        assert find_split("PEPTQ[Deamidated]DE") == find_split("PEPTEDE"), (
             "Q[Deamidated] and E variants must land in the same split"
         )
 
@@ -965,7 +960,7 @@ class TestCreateDatasetsIsobaricNormalization:
     def test_deamidation_normalization_preserves_original_sequences(self, tmp_path):
         """Output MGFs retain original sequences even with deamidation normalization."""
         spectra = [
-            ("PEPT[N[Deamidated]]DE", [100.0], [1.0]),
+            ("PEPTN[Deamidated]DE", [100.0], [1.0]),
             ("PEPTDDE", [100.0], [1.0]),
         ]
         for i in range(28):
@@ -980,7 +975,7 @@ class TestCreateDatasetsIsobaricNormalization:
         test = _read_mgf(tmp_path / "out.test.mgf")
 
         all_seqs = set(_get_peptides(train + val + test))
-        assert "PEPT[N[Deamidated]]DE" in all_seqs, (
+        assert "PEPTN[Deamidated]DE" in all_seqs, (
             "Original N[Deamidated] sequence must be preserved in output"
         )
         assert "PEPTDDE" in all_seqs
@@ -1003,7 +998,7 @@ class TestCreateDatasetsIsobaricNormalization:
 
         mgf = _write_mgf(
             tmp_path / "new.mgf",
-            [("PEPT[N[Deamidated]]DE", [100.0], [1.0])]
+            [("PEPTN[Deamidated]DE", [100.0], [1.0])]
             + [(f"NEW{i}", [100.0], [1.0]) for i in range(19)],
         )
         output_root = str(tmp_path / "out")
@@ -1022,8 +1017,8 @@ class TestCreateDatasetsIsobaricNormalization:
         val_seqs = set(_get_peptides(val))
         test_seqs = set(_get_peptides(test))
 
-        assert "PEPT[N[Deamidated]]DE" in train_seqs, (
+        assert "PEPTN[Deamidated]DE" in train_seqs, (
             "N[Deamidated]-form should follow D-form into train"
         )
-        assert "PEPT[N[Deamidated]]DE" not in val_seqs
-        assert "PEPT[N[Deamidated]]DE" not in test_seqs
+        assert "PEPTN[Deamidated]DE" not in val_seqs
+        assert "PEPTN[Deamidated]DE" not in test_seqs

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -707,7 +707,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -724,7 +724,7 @@ class TestCreateDatasetsIsobaricNormalization:
         )
 
     def test_il_variants_counted_as_one_peptide(self, tmp_path):
-        """With normalize_isobaric=True, I/L variants count as a single peptide."""
+        """I/L variants count as a single peptide due to isobaric normalization."""
         # 10 I/L pairs + 80 unique = 90 sequences but only 80+10=90 canonical
         # peptides... actually each pair shares a canonical form, so 10 pairs
         # contribute 10 canonical peptides rather than 20.
@@ -737,7 +737,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -761,39 +761,41 @@ class TestCreateDatasetsIsobaricNormalization:
                 f"I/L pair PEP{i}I / PEP{i}L must be in the same split"
             )
 
-    def test_normalize_isobaric_false_treats_variants_independently(self, tmp_path):
-        """With normalize_isobaric=False, I/L variants are treated as distinct peptides."""
-        # With a fixed random seed and enough peptides, I/L variants CAN end up
-        # in different splits when normalization is off. We verify that the two
-        # sequences are treated as independent (i.e. both appear in the output).
+    def test_isobaric_normalization_is_unconditional(self, tmp_path):
+        """Isobaric normalization is always applied; there is no opt-out."""
+        # Verify that PEPTIDE and PEPTLDE (I/L variants) always land in the
+        # same split regardless of how create_datasets is called.
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=False)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
         test = _read_mgf(tmp_path / "out.test.mgf")
 
-        all_seqs = _get_peptides(train + val + test)
-        # Both sequences appear in the output regardless of normalization.
-        assert "PEPTIDE" in all_seqs
-        assert "PEPTLDE" in all_seqs
-        # Total spectra preserved.
-        assert len(all_seqs) == len(spectra)
+        def find_split(seq):
+            for name, sp in [("train", train), ("val", val), ("test", test)]:
+                if any(s["params"]["seq"] == seq for s in sp):
+                    return name
+            return None
+
+        assert find_split("PEPTIDE") == find_split("PEPTLDE")
+        # All spectra are preserved.
+        assert len(train) + len(val) + len(test) == len(spectra)
 
     def test_original_sequences_preserved_in_output(self, tmp_path):
-        """Output MGF files retain original sequences even when normalize_isobaric=True."""
+        """Output MGF files retain original sequences despite isobaric normalization."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -837,7 +839,6 @@ class TestCreateDatasetsIsobaricNormalization:
             mgf,
             output_root=output_root,
             existing_splits=existing,
-            normalize_isobaric=True,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -853,15 +854,14 @@ class TestCreateDatasetsIsobaricNormalization:
         assert "PEPTIDE" not in val_seqs
         assert "PEPTIDE" not in test_seqs
 
-    def test_il_normalization_default_is_true(self, tmp_path):
-        """normalize_isobaric defaults to True (I/L variants placed in same split)."""
+    def test_il_normalization_always_applied(self, tmp_path):
+        """I/L variants are always placed in the same split."""
         spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        # Call without normalize_isobaric — should default to True.
         create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -889,7 +889,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -916,7 +916,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -945,7 +945,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -973,7 +973,7 @@ class TestCreateDatasetsIsobaricNormalization:
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
         output_root = str(tmp_path / "out")
 
-        create_datasets(mgf, output_root=output_root, normalize_isobaric=True)
+        create_datasets(mgf, output_root=output_root)
 
         train = _read_mgf(tmp_path / "out.train.mgf")
         val = _read_mgf(tmp_path / "out.val.mgf")
@@ -1012,7 +1012,6 @@ class TestCreateDatasetsIsobaricNormalization:
             mgf,
             output_root=output_root,
             existing_splits=existing,
-            normalize_isobaric=True,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -898,8 +898,12 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTN[Deamidated]DE") == find_split(
-            "PEPTDDE"
+        split_n = find_split("PEPTN[Deamidated]DE")
+        split_d = find_split("PEPTDDE")
+        assert split_n is not None, "PEPTN[Deamidated]DE not found in any split"
+        assert split_d is not None, "PEPTDDE not found in any split"
+        assert (
+            split_n == split_d
         ), "N[Deamidated] and D variants must land in the same split"
 
     def test_deamidated_q_and_e_land_in_same_split(self, tmp_path):
@@ -925,8 +929,12 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("PEPTQ[Deamidated]DE") == find_split(
-            "PEPTEDE"
+        split_q = find_split("PEPTQ[Deamidated]DE")
+        split_e = find_split("PEPTEDE")
+        assert split_q is not None, "PEPTQ[Deamidated]DE not found in any split"
+        assert split_e is not None, "PEPTEDE not found in any split"
+        assert (
+            split_q == split_e
         ), "Q[Deamidated] and E variants must land in the same split"
 
     def test_all_three_normalizations_together(self, tmp_path):
@@ -954,7 +962,13 @@ class TestCreateDatasetsIsobaricNormalization:
                     return name
             return None
 
-        assert find_split("IN[Deamidated]Q[Deamidated]K") == find_split("LDEK"), (
+        split_inqk = find_split("IN[Deamidated]Q[Deamidated]K")
+        split_ldek = find_split("LDEK")
+        assert (
+            split_inqk is not None
+        ), "IN[Deamidated]Q[Deamidated]K not found in any split"
+        assert split_ldek is not None, "LDEK not found in any split"
+        assert split_inqk == split_ldek, (
             "Peptide with I, N[Deamidated], and Q[Deamidated] must land in "
             "the same split as its canonical D/E/L form"
         )

--- a/tests/test_mskb2proforma.py
+++ b/tests/test_mskb2proforma.py
@@ -1,0 +1,258 @@
+"""Tests for mskb2proforma — MassIVE-KB to ProForma sequence converter."""
+
+import pyteomics.mgf
+import pytest
+
+from casanovoutils.mskb2proforma import _convert_seq, convert
+
+# ---------------------------------------------------------------------------
+# _convert_seq — unit tests for the pure conversion function
+# ---------------------------------------------------------------------------
+
+
+class TestConvertSeqPlain:
+    def test_no_modifications(self):
+        """A bare amino-acid sequence is returned unchanged."""
+        assert _convert_seq("PEPTIDE") == "PEPTIDE"
+
+    def test_single_residue(self):
+        """A single residue with no modifications is returned unchanged."""
+        assert _convert_seq("A") == "A"
+
+
+class TestConvertSeqNterminal:
+    def test_acetyl(self):
+        """+42.011 N-terminal shift maps to named [Acetyl]- token."""
+        assert _convert_seq("+42.011PEPTIDE") == "[Acetyl]-PEPTIDE"
+
+    def test_carbamyl(self):
+        """+43.006 N-terminal shift maps to named [Carbamyl]- token."""
+        assert _convert_seq("+43.006PEPTIDE") == "[Carbamyl]-PEPTIDE"
+
+    def test_ammonia_loss(self):
+        """-17.027 N-terminal shift maps to named [Ammonia-loss]- token."""
+        assert _convert_seq("-17.027PEPTIDE") == "[Ammonia-loss]-PEPTIDE"
+
+    def test_tmt_nterm(self):
+        """+229.163 N-terminal shift (TMT label) maps to a numeric token."""
+        result = _convert_seq("+229.163PEPTIDE")
+        assert result == "[+229.163]-PEPTIDE"
+
+    def test_unknown_nterm_positive(self):
+        """An unknown positive N-terminal shift is formatted as [+mass]-."""
+        result = _convert_seq("+28.031PEPTIDE")
+        assert result == "[+28.031]-PEPTIDE"
+
+    def test_unknown_nterm_negative(self):
+        """An unknown negative N-terminal shift is formatted as [mass]-."""
+        result = _convert_seq("-18.011PEPTIDE")
+        assert result == "[-18.011]-PEPTIDE"
+
+    def test_combined_tmt_acetyl(self):
+        """+229.163+42.011 sums to +271.174, producing one numeric token."""
+        result = _convert_seq("+229.163+42.011PEPTIDE")
+        assert result == "[+271.174]-PEPTIDE"
+
+    def test_combined_tmt_carbamyl(self):
+        """+229.163+43.006 sums to +272.169, producing one numeric token."""
+        result = _convert_seq("+229.163+43.006PEPTIDE")
+        assert result == "[+272.169]-PEPTIDE"
+
+    def test_combined_tmt_ammonia_loss(self):
+        """+229.163-17.027 sums to +212.136 — maps to named token if present,
+        otherwise numeric."""
+        result = _convert_seq("+229.163-17.027PEPTIDE")
+        assert result == "[+212.136]-PEPTIDE"
+
+    def test_combined_carbamyl_ammonia_loss_named(self):
+        """+43.006-17.027 == +25.979 maps to the named token +25.980265."""
+        result = _convert_seq("+43.006-17.027PEPTIDE")
+        assert result == "[+25.980265]-PEPTIDE"
+
+    def test_combined_labeling_with_residues(self):
+        """Combined N-term mod summed correctly alongside per-residue mods."""
+        result = _convert_seq("+229.163+42.011AC+57.021K")
+        assert result == "[+271.174]-AC[Carbamidomethyl]K"
+
+
+class TestConvertSeqResidues:
+    def test_carbamidomethyl_cys(self):
+        """C+57.021 maps to C[Carbamidomethyl]."""
+        assert _convert_seq("AC+57.021G") == "AC[Carbamidomethyl]G"
+
+    def test_oxidized_met(self):
+        """M+15.995 maps to M[Oxidation]."""
+        assert _convert_seq("AM+15.995G") == "AM[Oxidation]G"
+
+    def test_deamidated_asn(self):
+        """N+0.984 maps to N[Deamidated]."""
+        assert _convert_seq("AN+0.984G") == "AN[Deamidated]G"
+
+    def test_deamidated_gln(self):
+        """Q+0.984 maps to Q[Deamidated]."""
+        assert _convert_seq("AQ+0.984G") == "AQ[Deamidated]G"
+
+    def test_phospho_ser(self):
+        """S+79.966 maps to S[Phospho]."""
+        assert _convert_seq("AS+79.966G") == "AS[Phospho]G"
+
+    def test_phospho_thr(self):
+        """T+79.966 maps to T[Phospho]."""
+        assert _convert_seq("AT+79.966G") == "AT[Phospho]G"
+
+    def test_phospho_tyr(self):
+        """Y+79.966 maps to Y[Phospho]."""
+        assert _convert_seq("AY+79.966G") == "AY[Phospho]G"
+
+    def test_tmt_lys(self):
+        """K+229.163 (TMT label on lysine) maps to K[+229.163]."""
+        assert _convert_seq("AK+229.163G") == "AK[+229.163]G"
+
+    def test_dimethyl_lys(self):
+        """K+28.031 maps to K[+28.031]."""
+        assert _convert_seq("AK+28.031G") == "AK[+28.031]G"
+
+    def test_heavy_lys(self):
+        """K+8.014 (heavy isotope label) maps to K[+8.014]."""
+        assert _convert_seq("AK+8.014G") == "AK[+8.014]G"
+
+    def test_heavy_arg(self):
+        """R+10.008 (heavy isotope label) maps to R[+10.008]."""
+        assert _convert_seq("AR+10.008G") == "AR[+10.008]G"
+
+    def test_unknown_residue_mod_negative(self):
+        """Unknown negative residue shift is formatted as AA[-mass]."""
+        assert _convert_seq("AW-1.000G") == "AW[-1.000]G"
+
+    def test_multiple_residue_mods(self):
+        """Multiple modified residues in a sequence are all converted."""
+        result = _convert_seq("C+57.021M+15.995PEPTIDE")
+        assert result == "C[Carbamidomethyl]M[Oxidation]PEPTIDE"
+
+
+class TestConvertSeqRealWorldExamples:
+    """Representative sequences taken from the actual MassIVE-KB v2 dataset."""
+
+    def test_tmt_cterm_lys(self):
+        """+229.163 N-term and K+229.163 C-term, both converted."""
+        result = _convert_seq("+229.163GANHTLVLDSQK+229.163")
+        assert result == "[+229.163]-GANHTLVLDSQK[+229.163]"
+
+    def test_tmt_acetyl_and_cam(self):
+        """+229.163+42.011 N-term summed, C+57.021 named, K+229.163 numeric."""
+        result = _convert_seq("+229.163+42.011AC+57.021GANHTLVLDSQK+229.163")
+        assert result == "[+271.174]-AC[Carbamidomethyl]GANHTLVLDSQK[+229.163]"
+
+    def test_no_nterm_with_phospho(self):
+        """Phosphorylated sequence with no N-terminal modification."""
+        result = _convert_seq("AAGS+79.966PEPTIDE")
+        assert result == "AAGS[Phospho]PEPTIDE"
+
+
+# ---------------------------------------------------------------------------
+# convert — integration tests for the file-to-file converter
+# ---------------------------------------------------------------------------
+
+_SMALL_MGF = """\
+BEGIN IONS
+TITLE=spec1
+PEPMASS=500.0
+CHARGE=2+
+SEQ=C+57.021PEPTIDE
+100.0 10
+200.0 20
+END IONS
+
+BEGIN IONS
+TITLE=spec2
+PEPMASS=600.0
+CHARGE=3+
+SEQ=+42.011AGK
+150.0 15
+250.0 25
+END IONS
+
+BEGIN IONS
+TITLE=spec3
+PEPMASS=700.0
+CHARGE=2+
+100.0 10
+200.0 20
+END IONS
+"""
+
+
+class TestConvert:
+    def test_basic_conversion(self, tmp_path):
+        """SEQ fields are converted to ProForma; non-SEQ fields pass through."""
+        inp = tmp_path / "in.mgf"
+        out = tmp_path / "out.mgf"
+        inp.write_text(_SMALL_MGF)
+
+        convert(inp, out)
+
+        spectra = list(pyteomics.mgf.read(str(out), use_index=False))
+        assert len(spectra) == 3
+        assert spectra[0]["params"]["seq"] == "C[Carbamidomethyl]PEPTIDE"
+        assert spectra[1]["params"]["seq"] == "[Acetyl]-AGK"
+
+    def test_no_seq_passes_through(self, tmp_path):
+        """Spectra without a SEQ field are written unchanged."""
+        inp = tmp_path / "in.mgf"
+        out = tmp_path / "out.mgf"
+        inp.write_text(_SMALL_MGF)
+
+        convert(inp, out)
+
+        spectra = list(pyteomics.mgf.read(str(out), use_index=False))
+        assert "seq" not in spectra[2]["params"]
+
+    def test_output_file_exists_raises(self, tmp_path):
+        """FileExistsError when output exists and overwrite=False."""
+        inp = tmp_path / "in.mgf"
+        out = tmp_path / "out.mgf"
+        inp.write_text(_SMALL_MGF)
+        out.write_text("existing")
+
+        with pytest.raises(FileExistsError):
+            convert(inp, out, overwrite=False)
+
+    def test_overwrite_flag(self, tmp_path):
+        """overwrite=True allows clobbering an existing output file."""
+        inp = tmp_path / "in.mgf"
+        out = tmp_path / "out.mgf"
+        inp.write_text(_SMALL_MGF)
+        out.write_text("existing")
+
+        convert(inp, out, overwrite=True)
+
+        spectra = list(pyteomics.mgf.read(str(out), use_index=False))
+        assert len(spectra) == 3
+
+    def test_same_path_raises(self, tmp_path):
+        """ValueError when input and output resolve to the same path."""
+        inp = tmp_path / "in.mgf"
+        inp.write_text(_SMALL_MGF)
+
+        with pytest.raises(ValueError):
+            convert(inp, inp)
+
+    def test_combined_nterm_summed(self, tmp_path):
+        """Combined N-terminal shifts are summed into one ProForma token."""
+        mgf_text = """\
+BEGIN IONS
+TITLE=s1
+PEPMASS=900.0
+CHARGE=2+
+SEQ=+229.163+42.011PEPTIDEK+229.163
+100.0 10
+END IONS
+"""
+        inp = tmp_path / "in.mgf"
+        out = tmp_path / "out.mgf"
+        inp.write_text(mgf_text)
+
+        convert(inp, out)
+
+        spectra = list(pyteomics.mgf.read(str(out), use_index=False))
+        assert spectra[0]["params"]["seq"] == "[+271.174]-PEPTIDEK[+229.163]"

--- a/tests/test_mskb2proforma.py
+++ b/tests/test_mskb2proforma.py
@@ -48,6 +48,10 @@ class TestConvertSeqNterminal:
         result = _convert_seq("-18.011PEPTIDE")
         assert result == "[-18.011]-PEPTIDE"
 
+    def test_zero_nterm_shift_omitted(self):
+        """A net N-terminal shift of zero produces no N-terminal token."""
+        assert _convert_seq("+17.027-17.027PEPTIDE") == "PEPTIDE"
+
     def test_combined_tmt_acetyl(self):
         """+229.163+42.011 sums to +271.174, producing one numeric token."""
         result = _convert_seq("+229.163+42.011PEPTIDE")
@@ -65,9 +69,9 @@ class TestConvertSeqNterminal:
         assert result == "[+212.136]-PEPTIDE"
 
     def test_combined_carbamyl_ammonia_loss_named(self):
-        """+43.006-17.027 == +25.979 maps to the named token +25.980265."""
+        """+43.006-17.027 == +25.979 maps to the named token +25.979265."""
         result = _convert_seq("+43.006-17.027PEPTIDE")
-        assert result == "[+25.980265]-PEPTIDE"
+        assert result == "[+25.979265]-PEPTIDE"
 
     def test_combined_labeling_with_residues(self):
         """Combined N-term mod summed correctly alongside per-residue mods."""

--- a/tests/test_mskb2proforma.py
+++ b/tests/test_mskb2proforma.py
@@ -44,7 +44,7 @@ class TestConvertSeqNterminal:
         assert result == "[+28.031]-PEPTIDE"
 
     def test_unknown_nterm_negative(self):
-        """An unknown negative N-terminal shift is formatted as [mass]-."""
+        """An unknown negative N-terminal shift is formatted as [-mass]-."""
         result = _convert_seq("-18.011PEPTIDE")
         assert result == "[-18.011]-PEPTIDE"
 


### PR DESCRIPTION
## Summary

- Adds a new `mskb2proforma` submodule with a file-to-file converter that rewrites the `SEQ` field in annotated MGF files from MassIVE-KB notation to ProForma.
- Named per-residue mods are mapped to their ProForma names (e.g. `C+57.021` -> `C[Carbamidomethyl]`, `S+79.966` -> `S[Phospho]`); unknown shifts use the numeric form `AA[+mass]`.
- Named N-terminal mods are mapped to their ProForma names (Acetyl, Carbamyl, Ammonia-loss); unknown shifts use the numeric form `[+mass]-`.
- Multiple stacked N-terminal shifts (e.g. `+229.163+42.011`) are summed into a single ProForma token -- required because Casanovo only supports one N-terminal modification token per peptide.
- Spectra without a `SEQ` field are passed through unchanged.
- The command is auto-registered in the casanovoutils CLI as `casanovoutils mskb2proforma`.

## Test plan

- [x] `test_no_modifications` -- bare sequence passes through unchanged
- [x] `test_acetyl`, `test_carbamyl`, `test_ammonia_loss` -- named N-terminal mods
- [x] `test_tmt_nterm`, `test_unknown_nterm_positive`, `test_unknown_nterm_negative` -- numeric N-terminal tokens
- [x] `test_combined_tmt_acetyl`, `test_combined_tmt_carbamyl`, `test_combined_tmt_ammonia_loss` -- combined N-terminal shifts summed
- [x] `test_combined_carbamyl_ammonia_loss_named` -- sum resolves to a named token
- [x] `test_combined_labeling_with_residues` -- combined N-term alongside per-residue mods
- [x] `test_carbamidomethyl_cys`, `test_oxidized_met`, `test_deamidated_asn`, `test_deamidated_gln` -- named residue mods
- [x] `test_phospho_ser`, `test_phospho_thr`, `test_phospho_tyr` -- phospho mods
- [x] `test_tmt_lys`, `test_dimethyl_lys`, `test_heavy_lys`, `test_heavy_arg` -- numeric residue mods
- [x] `test_unknown_residue_mod_negative`, `test_multiple_residue_mods`
- [x] Three real-world sequences from the MassIVE-KB v2 dataset
- [x] `test_basic_conversion`, `test_no_seq_passes_through` -- file-to-file integration
- [x] `test_output_file_exists_raises`, `test_overwrite_flag`, `test_same_path_raises` -- error handling
- [x] `test_combined_nterm_summed` -- end-to-end with combined N-term in file

All 35 tests pass.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line converter for transforming MassIVE-KB annotated MGF sequences into ProForma notation.
  - Recognized modifications are converted to named ProForma tokens, while unknown modifications use numeric mass formats.
  - Leading mass shifts and other spectrum metadata are preserved during conversion.
  - Conversion supports progress reporting and summary statistics.
- **Bug Fixes**
  - Failed conversions retain the original sequence.
  - Added validation to prevent accidental in-place conversion and control output overwriting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->