### PR TITLE
Improve logging detail in create_datasets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added flag to convert sequences from MassIVE-KB PTM notation to ProForma before
+  splitting in `casanovoutils datasets`
 - `casanovoutils mgf pipeline`: chain shuffle, downsample, and purge-redundant
   in a single command with each stage independently optional.
 - `casanovoutils mgf purge-redundant`: remove near-duplicate peaks within each
@@ -18,6 +20,7 @@
 
 ### Changed
 
+- Improved logging detail in `casanovoutils datasets`
 - All CLI entry points consolidated into a single `casanovoutils` command with
   nested subcommands (`mgf`, `denovo`, `dump-residues`). The previous separate
   entry points (`graph-prec-cov`, `downsample-ms`, `mgf-utils`,

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -419,11 +419,11 @@ Create peptide-level train/validation/test splits from annotated MGF files.
 Peptides are split 80 / 10 / 10 by unique sequence to prevent leakage between
 splits.
 
-For each split, the following output files are written:
+The following output files are written:
 
 - `<output_root>.{train,val,test}.mgf` — spectra assigned to each split
 - `<output_root>.{train,val,test}.peptides.txt` — tab-separated modified and bare sequences
-- `<output_root>.log.txt` — run log with spectrum and peptide counts
+- `<output_root>.log.txt` — single run-level log with spectrum and peptide counts
 
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -424,7 +424,7 @@ splits. Outputs three MGF files: `<output_root>.train.mgf`, `.val.mgf`, and
 | --- | --- | --- | --- |
 | `*mgf_files` | path(s) | required | One or more annotated MGF files |
 | `--output_root` | str | required | Base path for output files |
-| `--spectra_per_peptide` | int | `None` | Cap spectra per peptide from new input files |
+| `--spectra_per_precursor` | int | `None` | Cap spectra per (peptide, charge state) precursor from new input files |
 | `--random_seed` | int | `42` | Random seed for reproducibility |
 | `--overwrite` | bool | `False` | Overwrite existing output files |
 | `--existing_splits` | paths | `None` | Tuple of existing (train, val, test) MGF paths to extend |
@@ -436,9 +436,9 @@ splits. Outputs three MGF files: `<output_root>.train.mgf`, `.val.mgf`, and
 # Basic split
 casanovoutils datasets input.mgf --output_root splits/run1
 
-# Multiple input files, cap at 3 spectra per peptide
+# Multiple input files, cap at 3 spectra per precursor
 casanovoutils datasets a.mgf b.mgf --output_root splits/combined \
-  --spectra_per_peptide 3
+  --spectra_per_precursor 3
 ```
 
 ---

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -417,8 +417,13 @@ casanovoutils summarize_mgf peptide-lengths input.mgf
 
 Create peptide-level train/validation/test splits from annotated MGF files.
 Peptides are split 80 / 10 / 10 by unique sequence to prevent leakage between
-splits. Outputs three MGF files: `<output_root>.train.mgf`, `.val.mgf`, and
-`.test.mgf`.
+splits.
+
+For each split, the following output files are written:
+
+- `<output_root>.{train,val,test}.mgf` — spectra assigned to each split
+- `<output_root>.{train,val,test}.peptides.txt` — tab-separated modified and bare sequences
+- `<output_root>.log.txt` — run log with spectrum and peptide counts
 
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -429,6 +434,7 @@ splits. Outputs three MGF files: `<output_root>.train.mgf`, `.val.mgf`, and
 | `--overwrite` | bool | `False` | Overwrite existing output files |
 | `--existing_splits` | paths | `None` | Tuple of existing (train, val, test) MGF paths to extend |
 | `--combine_with_existing` | bool | `False` | Include existing spectra in output alongside new ones |
+| `--mskb_format` | bool | `False` | Convert input sequences from MassIVE-KB PTM notation to ProForma before splitting |
 
 **Examples:**
 
@@ -439,6 +445,9 @@ casanovoutils datasets input.mgf --output_root splits/run1
 # Multiple input files, cap at 3 spectra per precursor
 casanovoutils datasets a.mgf b.mgf --output_root splits/combined \
   --spectra_per_precursor 3
+
+# Convert MassIVE-KB PTM notation to ProForma before splitting
+casanovoutils datasets input.mgf --output_root splits/run1 --mskb_format
 ```
 
 ---

--- a/src/casanovoutils/__init__.py
+++ b/src/casanovoutils/__init__.py
@@ -16,33 +16,51 @@ from typing import Optional
 def configure_logging(
     log_file: Optional[PathLike] = None,
     level: Optional[int] = None,
-) -> None:
+    file_mode: str = "a",
+) -> Optional[logging.FileHandler]:
     """
     Configure logging to stdout, optionally also writing to a file.
 
-    This function is a no-op if it's already been called.
+    The stdout handler is only added once (subsequent calls are a no-op for
+    the base configuration).  If *log_file* is provided, a file handler is
+    always added, even if logging was already configured, so callers can
+    direct output from a specific command to a dedicated log file.
 
     Parameters
     ----------
     log_file : PathLike, optional
         If provided, log output is written to this file in addition to stdout.
-        The file is opened in append mode. If ``None`` (default), only stdout
-        is used.
+        If ``None`` (default), only stdout is used.
     level : int, optional
         Logging level. If ``None`` (default), reads from the ``LOG_LEVEL``
         environment variable. If that is not set, defaults to ``logging.INFO``.
-    """
-    if logging.root.handlers:
-        return
+    file_mode : str, default "a"
+        File open mode passed to ``logging.FileHandler``.  Use ``"w"`` to
+        truncate the file on each run, ``"a"`` (default) to append.
 
+    Returns
+    -------
+    logging.FileHandler or None
+        The file handler that was added, or ``None`` if *log_file* was not
+        provided.  The caller is responsible for removing and closing the
+        handler when it is no longer needed.
+    """
     level = os.environ.get("LOG_LEVEL", logging.INFO) if level is None else level
-    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+
+    if not logging.root.handlers:
+        handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
+        logging.basicConfig(
+            level=level,
+            format="%(asctime)s | %(levelname)s | %(message)s",
+            handlers=handlers,
+        )
 
     if log_file is not None:
-        handlers.append(logging.FileHandler(log_file))
+        file_handler = logging.FileHandler(log_file, mode=file_mode)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+        )
+        logging.root.addHandler(file_handler)
+        return file_handler
 
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s | %(levelname)s | %(message)s",
-        handlers=handlers,
-    )
+    return None

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -663,8 +663,10 @@ def create_datasets(
         If False, only new spectra are written.
     mskb_format : bool, default=False
         If True, input MGF files are assumed to use MassIVE-KB PTM notation
-        and are converted to ProForma format before splitting. Conversion
-        raises a ``ValueError`` if any sequence cannot be converted.
+        and are converted to ProForma format before splitting. The output MGF
+        files will contain the converted ProForma sequences, not the original
+        MassIVE-KB strings. Conversion raises a ``ValueError`` if any
+        sequence cannot be converted.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -220,9 +220,7 @@ def _collect_peptide_counts(
         f"{len(pep_counts)}"
         + (f" ({n_collapsed} sequences merged)" if n_collapsed > 0 else "")
     )
-    logging.info(
-        f"Unique precursors (sequence + charge state): {len(sampling_counts)}"
-    )
+    logging.info(f"Unique precursors (sequence + charge state): {len(sampling_counts)}")
     return pep_counts, sampling_counts, total_spectra
 
 

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -477,7 +477,9 @@ def _write_splits(
     sampled_indices : dict[tuple, set[int]]
         Per-(peptide, charge) sets of 0-based spectrum indices to retain.
     spectra_per_precursor : int or None
-        Maximum spectra per (peptide, charge) (used to check sampled_indices).
+        Maximum spectra per (peptide, charge) combination.  Used to decide
+        whether to consult *sampled_indices* for a given precursor.  If
+        ``None``, all spectra are retained (no cap applied).
     existing_splits : tuple of PathLike or None
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
@@ -703,15 +705,12 @@ def create_datasets(
                 f"Use --overwrite to overwrite."
             )
 
-    configure_logging()
-    log_file = pathlib.Path(f"{output_root}.log.txt")
-    # Use mode="w" so log.txt is always a single-run artifact, consistent with
-    # overwrite semantics for the MGF and peptides.txt outputs.
-    file_handler = logging.FileHandler(log_file, mode="w")
-    file_handler.setFormatter(
-        logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    # Use file_mode="w" so log.txt is always a single-run artifact, consistent
+    # with overwrite semantics for the MGF and peptides.txt outputs.
+    file_handler = configure_logging(
+        pathlib.Path(f"{output_root}.log.txt"),
+        file_mode="w",
     )
-    logging.root.addHandler(file_handler)
 
     try:
         random.seed(random_seed)

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -183,6 +183,7 @@ def _collect_peptide_counts(
     """
     pep_counts: dict[str, int] = {}
     sampling_counts: dict[tuple, int] = {}
+    raw_seqs: set[str] = set()
     total_spectra = 0
     for mgf_file in mgf_files:
         file_count = 0
@@ -202,6 +203,7 @@ def _collect_peptide_counts(
                         f"Missing 'seq' in spectrum params for spectrum "
                         f"{spectrum_index} in file {mgf_file}"
                     ) from exc
+                raw_seqs.add(seq)
                 pep_key = _canonical(seq)
                 pep_counts[pep_key] = pep_counts.get(pep_key, 0) + 1
                 samp_key = _sampling_key(spectrum)
@@ -211,7 +213,16 @@ def _collect_peptide_counts(
         total_spectra += file_count
 
     logging.info(f"Total spectra read: {total_spectra}")
-    logging.info(f"Unique peptides: {len(pep_counts)}")
+    logging.info(f"Unique raw sequences: {len(raw_seqs)}")
+    n_collapsed = len(raw_seqs) - len(pep_counts)
+    logging.info(
+        f"Unique canonical peptides (after I/L and deamidation collapsing): "
+        f"{len(pep_counts)}"
+        + (f" ({n_collapsed} sequences merged)" if n_collapsed > 0 else "")
+    )
+    logging.info(
+        f"Unique precursors (sequence + charge state): {len(sampling_counts)}"
+    )
     return pep_counts, sampling_counts, total_spectra
 
 
@@ -268,9 +279,16 @@ def _assign_splits(
             else:
                 spectra_after += count
         eliminated = total_spectra - spectra_after
+        n_capped = len(sampled_indices)
+        n_precursors = len(sampling_counts)
+        logging.info(
+            f"Unique precursors exceeding spectra_per_precursor="
+            f"{spectra_per_precursor}: {n_capped} of {n_precursors}"
+        )
         logging.info(
             f"Spectra eliminated by spectra_per_precursor="
-            f"{spectra_per_precursor}: {eliminated}"
+            f"{spectra_per_precursor}: {eliminated} "
+            f"({spectra_after} retained)"
         )
 
     # Handle existing splits if provided.
@@ -451,6 +469,13 @@ def _assign_splits(
         pep_to_split[pep] = "val"
     for pep in test_peps:
         pep_to_split[pep] = "test"
+
+    logging.info(
+        f"Canonical peptides assigned: "
+        f"train={len(train_peps)}, "
+        f"val={len(val_peps)}, "
+        f"test={len(test_peps)}"
+    )
 
     return pep_to_split, sampled_indices, existing_peps
 

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -703,7 +703,13 @@ def create_datasets(
                 f"Use --overwrite to overwrite."
             )
 
-    configure_logging(pathlib.Path(f"{output_root}.log.txt"))
+    configure_logging()
+    log_file = pathlib.Path(f"{output_root}.log.txt")
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    )
+    logging.root.addHandler(file_handler)
 
     random.seed(random_seed)
 

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -23,6 +23,10 @@ _WRITE_BUFFER_SIZE = 1000
 # (for N-terminal mods like "[Acetyl]-").
 _MOD_RE = re.compile(r"\[[^\]]*\]-?")
 
+# Matches MassIVE-KB PTM notation: a sign+decimal mass shift at the start of
+# a sequence (N-terminal) or immediately after a residue letter.
+_MSKB_SEQ_RE = re.compile(r"(?:^|[A-Z])[+-]\d+\.\d+")
+
 
 def _canonical(seq: str) -> str:
     """Return the canonical form of a peptide sequence.
@@ -86,17 +90,19 @@ def _strip_mods(seq: str) -> str:
     return _MOD_RE.sub("", seq)
 
 
-def _write_peptides_txt(output_root: str) -> None:
+def _write_peptides_txt(
+    output_root: str,
+    mod_to_bare_by_split: dict[str, dict[str, str]],
+) -> None:
     """Write ``<split>.peptides.txt`` files for each split.
 
-    Reads each output MGF and collects every unique ``seq`` value.  Each output
-    line contains two tab-separated columns: the modified sequence (ProForma,
-    as it appears in the MGF) and the canonical bare sequence.  The canonical
-    bare sequence is produced by applying the same isobaric substitutions used
-    for splitting (I→L, N[Deamidated]→D, Q[Deamidated]→E) and then stripping
-    all remaining modification tokens, so mass-equivalent variants share a
-    single bare sequence.  Lines are sorted alphabetically by the canonical
-    bare sequence, then by the modified sequence.
+    Each output line contains two tab-separated columns: the modified sequence
+    (ProForma, as it appears in the MGF) and the canonical bare sequence.  The
+    canonical bare sequence is produced by applying the same isobaric
+    substitutions used for splitting (I→L, N[Deamidated]→D, Q[Deamidated]→E)
+    and then stripping all remaining modification tokens, so mass-equivalent
+    variants share a single bare sequence.  Lines are sorted alphabetically by
+    the canonical bare sequence, then by the modified sequence.
 
     Also logs, per split, the number of unique modified sequences and the
     number of unique bare sequences.
@@ -104,18 +110,14 @@ def _write_peptides_txt(output_root: str) -> None:
     Parameters
     ----------
     output_root : str
-        Root path used to locate output MGF files and write peptides files.
+        Root path used to write peptides files.
+    mod_to_bare_by_split : dict[str, dict[str, str]]
+        Mapping of split name to ``{modified_seq: bare_seq}`` dict, collected
+        during pass 2 by ``_write_splits``.
     """
     for split in ("train", "val", "test"):
-        mgf_path = pathlib.Path(f"{output_root}.{split}.mgf")
         pep_path = pathlib.Path(f"{output_root}.{split}.peptides.txt")
-        # Map modified seq -> bare seq (many-to-one).
-        mod_to_bare: dict[str, str] = {}
-        with pyteomics.mgf.read(str(mgf_path), use_index=False) as reader:
-            for spectrum in reader:
-                seq = spectrum["params"].get("seq")
-                if seq and seq not in mod_to_bare:
-                    mod_to_bare[seq] = _strip_mods(_canonical(seq))
+        mod_to_bare = mod_to_bare_by_split[split]
         pairs = sorted(mod_to_bare.items(), key=lambda kv: (kv[1], kv[0]))
         with open(pep_path, "w") as fh:
             for modified, bare in pairs:
@@ -448,7 +450,7 @@ def _write_splits(
     spectra_per_precursor: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
-) -> tuple[dict[str, int], dict[str, set[str]]]:
+) -> tuple[dict[str, int], dict[str, set[str]], dict[str, dict[str, str]]]:
     """Pass 2: stream spectra to output MGF files.
 
     Parameters
@@ -474,6 +476,9 @@ def _write_splits(
         Number of spectra written to each split.
     split_pep_sets : dict[str, set[str]]
         Set of new canonical peptides assigned to each split.
+    mod_to_bare_by_split : dict[str, dict[str, str]]
+        Per-split mapping of modified sequence to canonical bare sequence,
+        collected during writing for use by ``_write_peptides_txt``.
     """
     split_pep_sets = {
         split: {pep for pep, s in pep_to_split.items() if s == split}
@@ -488,6 +493,12 @@ def _write_splits(
         "train": 0,
         "val": 0,
         "test": 0,
+    }
+
+    mod_to_bare_by_split: dict[str, dict[str, str]] = {
+        "train": {},
+        "val": {},
+        "test": {},
     }
 
     with (
@@ -516,7 +527,10 @@ def _write_splits(
                 buffers[split_name].clear()
 
         def write_spectrum(split_name: str, spectrum: dict) -> None:
-            """Buffer a spectrum and flush when buffer is full."""
+            """Buffer a spectrum, track its sequence, and flush when full."""
+            seq = spectrum["params"].get("seq")
+            if seq and seq not in mod_to_bare_by_split[split_name]:
+                mod_to_bare_by_split[split_name][seq] = _strip_mods(_canonical(seq))
             buffers[split_name].append(spectrum)
             split_spectra_counts[split_name] += 1
             if len(buffers[split_name]) >= _WRITE_BUFFER_SIZE:
@@ -567,7 +581,7 @@ def _write_splits(
         for split_name in ("train", "val", "test"):
             flush_buffer(split_name)
 
-    return split_spectra_counts, split_pep_sets
+    return split_spectra_counts, split_pep_sets, mod_to_bare_by_split
 
 
 def create_datasets(
@@ -634,7 +648,9 @@ def create_datasets(
     existing_splits : tuple of PathLike, optional
         A tuple of three MGF file paths (train, validation, test) containing
         pre-existing splits. Peptides from new input files that already appear
-        in an existing split are routed to that same split.
+        in an existing split are routed to that same split. The files must use
+        ProForma sequence notation; MassIVE-KB notation is not supported and
+        will raise a ``ValueError``.
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
@@ -656,6 +672,21 @@ def create_datasets(
         raise ValueError(
             "combine_with_existing=True requires existing_splits to be provided."
         )
+
+    if existing_splits is not None:
+        split_names = ("train", "val", "test")
+        for split_name, split_path in zip(split_names, existing_splits):
+            with pyteomics.mgf.read(str(split_path), use_index=False) as reader:
+                for spectrum in reader:
+                    seq = spectrum["params"].get("seq", "")
+                    if seq and _MSKB_SEQ_RE.search(seq):
+                        raise ValueError(
+                            f"Existing split '{split_name}' ({split_path}) "
+                            f"appears to use MassIVE-KB PTM notation "
+                            f"(e.g. sequence {seq!r}). "
+                            f"existing_splits must be in ProForma format."
+                        )
+                    break  # Only check first spectrum per file.
 
     if not overwrite:
         expected_files = [
@@ -698,7 +729,7 @@ def create_datasets(
             spectra_per_precursor,
         )
 
-        split_spectra_counts, split_pep_sets = _write_splits(
+        split_spectra_counts, split_pep_sets, mod_to_bare_by_split = _write_splits(
             mgf_files,
             output_root,
             pep_to_split,
@@ -723,7 +754,7 @@ def create_datasets(
         else:
             logging.info(f"{split_name}: {count} spectra, {len(peps)} peptides")
 
-    _write_peptides_txt(output_root)
+    _write_peptides_txt(output_root, mod_to_bare_by_split)
 
 
 COMMANDS: Commands = create_datasets

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -150,7 +150,13 @@ def _sampling_key(spectrum: dict) -> tuple[str, tuple]:
         charge values from the spectrum params (may be empty).
     """
     seq = spectrum["params"]["seq"]
-    charge = tuple(spectrum["params"].get("charge", []))
+    charge_raw = spectrum["params"].get("charge", [])
+    if isinstance(charge_raw, (list, tuple)):
+        charge = tuple(charge_raw)
+    elif charge_raw is None:
+        charge = ()
+    else:
+        charge = (charge_raw,)
     return (_canonical(seq), charge)
 
 
@@ -558,7 +564,7 @@ def _write_splits(
                         write_spectrum(split_name, spectrum)
 
         # Stream new input MGFs.
-        pep_counters: dict[tuple, int] = {}
+        precursor_counters: dict[tuple, int] = {}
         for mgf_file in mgf_files:
             with pyteomics.mgf.read(str(mgf_file), use_index=False) as reader:
                 for spectrum in tqdm.tqdm(
@@ -572,8 +578,8 @@ def _write_splits(
 
                     # Apply spectra_per_precursor filtering per (peptide, charge).
                     if spectra_per_precursor is not None:
-                        idx = pep_counters.get(samp_key, 0)
-                        pep_counters[samp_key] = idx + 1
+                        idx = precursor_counters.get(samp_key, 0)
+                        precursor_counters[samp_key] = idx + 1
                         if samp_key in sampled_indices:
                             if idx not in sampled_indices[samp_key]:
                                 continue

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -89,7 +89,7 @@ def _strip_mods(seq: str) -> str:
 def _write_peptides_txt(output_root: str) -> None:
     """Write ``<split>.peptides.txt`` files for each split.
 
-    Reads each output MGF and collects every unique SEQ value.  Each output
+    Reads each output MGF and collects every unique ``seq`` value.  Each output
     line contains two tab-separated columns: the modified sequence (ProForma,
     as it appears in the MGF) and the canonical bare sequence.  The canonical
     bare sequence is produced by applying the same isobaric substitutions used

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -166,26 +166,27 @@ def _collect_peptide_counts(
     total_spectra = 0
     for mgf_file in mgf_files:
         file_count = 0
-        for spectrum_index, spectrum in enumerate(
-            tqdm.tqdm(
-                pyteomics.mgf.read(str(mgf_file), use_index=False),
-                desc=f"Reading {mgf_file} (pass 1)",
-                unit="PSM",
-            ),
-            start=1,
-        ):
-            try:
-                seq = spectrum["params"]["seq"]
-            except KeyError as exc:
-                raise KeyError(
-                    f"Missing 'seq' in spectrum params for spectrum "
-                    f"{spectrum_index} in file {mgf_file}"
-                ) from exc
-            pep_key = _canonical(seq)
-            pep_counts[pep_key] = pep_counts.get(pep_key, 0) + 1
-            samp_key = _sampling_key(spectrum)
-            sampling_counts[samp_key] = sampling_counts.get(samp_key, 0) + 1
-            file_count += 1
+        with pyteomics.mgf.read(str(mgf_file), use_index=False) as reader:
+            for spectrum_index, spectrum in enumerate(
+                tqdm.tqdm(
+                    reader,
+                    desc=f"Reading {mgf_file} (pass 1)",
+                    unit="PSM",
+                ),
+                start=1,
+            ):
+                try:
+                    seq = spectrum["params"]["seq"]
+                except KeyError as exc:
+                    raise KeyError(
+                        f"Missing 'seq' in spectrum params for spectrum "
+                        f"{spectrum_index} in file {mgf_file}"
+                    ) from exc
+                pep_key = _canonical(seq)
+                pep_counts[pep_key] = pep_counts.get(pep_key, 0) + 1
+                samp_key = _sampling_key(spectrum)
+                sampling_counts[samp_key] = sampling_counts.get(samp_key, 0) + 1
+                file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
         total_spectra += file_count
 
@@ -267,20 +268,21 @@ def _assign_splits(
                 f"were provided."
             )
         for split_name, split_path in zip(split_names, existing_splits, strict=True):
-            for spectrum in tqdm.tqdm(
-                pyteomics.mgf.read(str(split_path), use_index=False),
-                desc=f"Reading existing {split_name}",
-                unit="PSM",
-            ):
-                try:
-                    seq = spectrum["params"]["seq"]
-                except KeyError as exc:
-                    raise KeyError(
-                        f"Missing 'seq' in spectrum params while reading "
-                        f"existing split '{split_name}' from file "
-                        f"'{split_path}'"
-                    ) from exc
-                existing_peps[split_name].add(_canonical(seq))
+            with pyteomics.mgf.read(str(split_path), use_index=False) as reader:
+                for spectrum in tqdm.tqdm(
+                    reader,
+                    desc=f"Reading existing {split_name}",
+                    unit="PSM",
+                ):
+                    try:
+                        seq = spectrum["params"]["seq"]
+                    except KeyError as exc:
+                        raise KeyError(
+                            f"Missing 'seq' in spectrum params while reading "
+                            f"existing split '{split_name}' from file "
+                            f"'{split_path}'"
+                        ) from exc
+                    existing_peps[split_name].add(_canonical(seq))
             logging.info(
                 f"Existing {split_name}: "
                 f"{len(existing_peps[split_name])} peptide"
@@ -514,38 +516,40 @@ def _write_splits(
             for split_name, split_path in zip(
                 split_names, existing_splits, strict=True
             ):
-                for spectrum in tqdm.tqdm(
-                    pyteomics.mgf.read(str(split_path), use_index=False),
-                    desc=f"Writing existing {split_name} (pass 2)",
-                    unit="PSM",
-                ):
-                    write_spectrum(split_name, spectrum)
+                with pyteomics.mgf.read(str(split_path), use_index=False) as reader:
+                    for spectrum in tqdm.tqdm(
+                        reader,
+                        desc=f"Writing existing {split_name} (pass 2)",
+                        unit="PSM",
+                    ):
+                        write_spectrum(split_name, spectrum)
 
         # Stream new input MGFs.
         pep_counters: dict[tuple, int] = {}
         for mgf_file in mgf_files:
-            for spectrum in tqdm.tqdm(
-                pyteomics.mgf.read(str(mgf_file), use_index=False),
-                desc=f"Writing {mgf_file} (pass 2)",
-                unit="PSM",
-            ):
-                seq = spectrum["params"]["seq"]
-                pep_key = _canonical(seq)
-                samp_key = _sampling_key(spectrum)
+            with pyteomics.mgf.read(str(mgf_file), use_index=False) as reader:
+                for spectrum in tqdm.tqdm(
+                    reader,
+                    desc=f"Writing {mgf_file} (pass 2)",
+                    unit="PSM",
+                ):
+                    seq = spectrum["params"]["seq"]
+                    pep_key = _canonical(seq)
+                    samp_key = _sampling_key(spectrum)
 
-                # Apply spectra_per_precursor filtering per (peptide, charge).
-                if spectra_per_precursor is not None:
-                    idx = pep_counters.get(samp_key, 0)
-                    pep_counters[samp_key] = idx + 1
-                    if samp_key in sampled_indices:
-                        if idx not in sampled_indices[samp_key]:
-                            continue
-                    # If samp_key not in sampled_indices, count <= limit,
-                    # so keep all.
+                    # Apply spectra_per_precursor filtering per (peptide, charge).
+                    if spectra_per_precursor is not None:
+                        idx = pep_counters.get(samp_key, 0)
+                        pep_counters[samp_key] = idx + 1
+                        if samp_key in sampled_indices:
+                            if idx not in sampled_indices[samp_key]:
+                                continue
+                        # If samp_key not in sampled_indices, count <= limit,
+                        # so keep all.
 
-                split_name = pep_to_split.get(pep_key)
-                if split_name is not None:
-                    write_spectrum(split_name, spectrum)
+                    split_name = pep_to_split.get(pep_key)
+                    if split_name is not None:
+                        write_spectrum(split_name, spectrum)
 
         # Flush remaining buffers.
         for split_name in ("train", "val", "test"):

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -3,6 +3,8 @@
 import logging
 import pathlib
 import random
+import re
+import tempfile
 from os import PathLike
 from typing import Optional
 
@@ -11,10 +13,15 @@ import pyteomics.mgf
 import tqdm
 
 from . import configure_logging
+from .mskb2proforma import convert as _mskb2proforma_convert
 from .types import Commands
 
 # Number of spectra to buffer per output file before flushing to disk.
 _WRITE_BUFFER_SIZE = 1000
+
+# Matches a bracket-enclosed modification token and an optional trailing dash
+# (for N-terminal mods like "[Acetyl]-").
+_MOD_RE = re.compile(r"\[[^\]]*\]-?")
 
 
 def _canonical(seq: str) -> str:
@@ -42,22 +49,71 @@ def _canonical(seq: str) -> str:
     str
         Canonical peptide sequence.
     """
-    # Replace I with L only at residue positions (bracket depth 0), so that
-    # uppercase I characters inside modification names are left untouched.
-    chars = []
-    depth = 0
-    for ch in seq:
-        if ch == "[":
-            depth += 1
-        elif ch == "]":
-            depth -= 1
-        elif ch == "I" and depth == 0:
-            ch = "L"
-        chars.append(ch)
-    seq = "".join(chars)
+    seq = seq.replace("I", "L")
     seq = seq.replace("N[Deamidated]", "D")
     seq = seq.replace("Q[Deamidated]", "E")
     return seq
+
+
+def _strip_mods(seq: str) -> str:
+    """Remove all modification tokens from a ProForma peptide sequence.
+
+    Strips bracket-enclosed modification names and masses, including
+    N-terminal modification tokens (e.g. ``[Acetyl]-``).
+
+    Parameters
+    ----------
+    seq : str
+        ProForma peptide sequence, e.g. ``"[Acetyl]-AC[Carbamidomethyl]GK"``.
+
+    Returns
+    -------
+    str
+        Bare amino-acid sequence, e.g. ``"ACGK"``.
+    """
+    return _MOD_RE.sub("", seq)
+
+
+def _write_peptides_txt(output_root: str) -> None:
+    """Write ``<split>.peptides.txt`` files for each split.
+
+    Reads each output MGF and collects every unique SEQ value.  Each output
+    line contains two tab-separated columns: the modified sequence (ProForma,
+    as it appears in the MGF) and the canonical bare sequence.  The canonical
+    bare sequence is produced by applying the same isobaric substitutions used
+    for splitting (I→L, N[Deamidated]→D, Q[Deamidated]→E) and then stripping
+    all remaining modification tokens, so mass-equivalent variants share a
+    single bare sequence.  Lines are sorted alphabetically by the canonical
+    bare sequence, then by the modified sequence.
+
+    Also logs, per split, the number of unique modified sequences and the
+    number of unique bare sequences.
+
+    Parameters
+    ----------
+    output_root : str
+        Root path used to locate output MGF files and write peptides files.
+    """
+    for split in ("train", "val", "test"):
+        mgf_path = pathlib.Path(f"{output_root}.{split}.mgf")
+        pep_path = pathlib.Path(f"{output_root}.{split}.peptides.txt")
+        # Map modified seq -> bare seq (many-to-one).
+        mod_to_bare: dict[str, str] = {}
+        with pyteomics.mgf.read(str(mgf_path), use_index=False) as reader:
+            for spectrum in reader:
+                seq = spectrum["params"].get("seq")
+                if seq and seq not in mod_to_bare:
+                    mod_to_bare[seq] = _strip_mods(_canonical(seq))
+        pairs = sorted(mod_to_bare.items(), key=lambda kv: (kv[1], kv[0]))
+        with open(pep_path, "w") as fh:
+            for modified, bare in pairs:
+                fh.write(f"{modified}\t{bare}\n")
+        n_modified = len(mod_to_bare)
+        n_bare = len(set(mod_to_bare.values()))
+        logging.info(
+            f"{split} peptides.txt: {n_modified} unique modified sequences, "
+            f"{n_bare} unique bare sequences"
+        )
 
 
 def _sampling_key(spectrum: dict) -> tuple[str, tuple]:
@@ -506,6 +562,7 @@ def create_datasets(
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
+    mskb_format: bool = False,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -537,8 +594,14 @@ def create_datasets(
     output_root : str
         Root path for the output files. Three MGF files will be created:
         ``<output_root>.train.mgf``, ``<output_root>.val.mgf``, and
-        ``<output_root>.test.mgf``. A log file ``<output_root>.log`` will
-        also be created.
+        ``<output_root>.test.mgf``. A two-column tab-separated peptides
+        file is written for each split:
+        ``<output_root>.[train,val,test].peptides.txt``. Column 1 is the
+        modified sequence (ProForma) and column 2 is the canonical bare
+        sequence (isobaric substitutions applied, then modification tokens
+        stripped); rows are sorted by canonical bare sequence then by
+        modified sequence. A log file ``<output_root>.log.txt``
+        is also created.
     spectra_per_precursor : int, optional
         If provided, randomly select at most this many spectra for each
         (peptide, precursor charge state) combination from the new input
@@ -559,6 +622,10 @@ def create_datasets(
     combine_with_existing : bool, default=False
         If True, output MGF files include both existing and new spectra.
         If False, only new spectra are written.
+    mskb_format : bool, default=False
+        If True, input MGF files are assumed to use MassIVE-KB PTM notation
+        and are converted to ProForma format before splitting. The output MGF
+        files always contain ProForma sequences.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -576,10 +643,11 @@ def create_datasets(
 
     if not overwrite:
         expected_files = [
-            pathlib.Path(f"{output_root}.{split}.mgf")
+            pathlib.Path(f"{output_root}.{split}.{ext}")
             for split in ("train", "val", "test")
+            for ext in ("mgf", "peptides.txt")
         ]
-        expected_files.append(pathlib.Path(f"{output_root}.log"))
+        expected_files.append(pathlib.Path(f"{output_root}.log.txt"))
         existing = [f for f in expected_files if f.exists()]
         if existing:
             file_list = ", ".join(str(f) for f in existing)
@@ -588,29 +656,41 @@ def create_datasets(
                 f"Use --overwrite to overwrite."
             )
 
-    configure_logging(pathlib.Path(f"{output_root}.log"))
+    configure_logging(pathlib.Path(f"{output_root}.log.txt"))
 
     random.seed(random_seed)
 
-    pep_counts, sampling_counts, total_spectra = _collect_peptide_counts(mgf_files)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        if mskb_format:
+            tmp = pathlib.Path(tmpdir)
+            converted = []
+            for i, src in enumerate(mgf_files):
+                src = pathlib.Path(src)
+                dst = tmp / f"converted_{i}_{src.name}"
+                logging.info(f"Converting {src} from MassIVE-KB format to ProForma...")
+                _mskb2proforma_convert(src, dst)
+                converted.append(dst)
+            mgf_files = tuple(converted)
 
-    pep_to_split, sampled_indices, existing_peps = _assign_splits(
-        pep_counts,
-        sampling_counts,
-        total_spectra,
-        existing_splits,
-        spectra_per_precursor,
-    )
+        pep_counts, sampling_counts, total_spectra = _collect_peptide_counts(mgf_files)
 
-    split_spectra_counts, split_pep_sets = _write_splits(
-        mgf_files,
-        output_root,
-        pep_to_split,
-        sampled_indices,
-        spectra_per_precursor,
-        existing_splits,
-        combine_with_existing,
-    )
+        pep_to_split, sampled_indices, existing_peps = _assign_splits(
+            pep_counts,
+            sampling_counts,
+            total_spectra,
+            existing_splits,
+            spectra_per_precursor,
+        )
+
+        split_spectra_counts, split_pep_sets = _write_splits(
+            mgf_files,
+            output_root,
+            pep_to_split,
+            sampled_indices,
+            spectra_per_precursor,
+            existing_splits,
+            combine_with_existing,
+        )
 
     # Log split summaries.
     for split_name in ("train", "val", "test"):
@@ -626,6 +706,8 @@ def create_datasets(
             )
         else:
             logging.info(f"{split_name}: {count} spectra, {len(peps)} peptides")
+
+    _write_peptides_txt(output_root)
 
 
 COMMANDS: Commands = create_datasets

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -60,9 +60,33 @@ def _canonical(seq: str) -> str:
     return seq
 
 
+def _sampling_key(spectrum: dict) -> tuple[str, tuple]:
+    """Return the key used for spectra_per_precursor counting.
+
+    The key is ``(canonical_seq, charge_tuple)`` so that spectra with the
+    same peptide sequence but different precursor charge states are counted
+    independently.  This allows each charge state to contribute up to
+    ``spectra_per_precursor`` spectra.
+
+    Parameters
+    ----------
+    spectrum : dict
+        A spectrum dict as returned by pyteomics.
+
+    Returns
+    -------
+    tuple[str, tuple]
+        ``(_canonical(seq), tuple(charge))`` where *charge* is the list of
+        charge values from the spectrum params (may be empty).
+    """
+    seq = spectrum["params"]["seq"]
+    charge = tuple(spectrum["params"].get("charge", []))
+    return (_canonical(seq), charge)
+
+
 def _collect_peptide_counts(
     mgf_files: tuple[PathLike, ...],
-) -> tuple[dict[str, int], int]:
+) -> tuple[dict[str, int], dict[tuple, int], int]:
     """Pass 1: stream all input MGF files and count spectra per peptide.
 
     Parameters
@@ -73,11 +97,16 @@ def _collect_peptide_counts(
     Returns
     -------
     pep_counts : dict[str, int]
-        Mapping of canonical peptide sequence to spectrum count.
+        Mapping of canonical peptide sequence to spectrum count.  Used for
+        split assignment (peptide-level).
+    sampling_counts : dict[tuple, int]
+        Mapping of ``(canonical_seq, charge_tuple)`` to spectrum count.
+        Used for per-charge-state ``spectra_per_precursor`` capping.
     total_spectra : int
         Total number of spectra read across all files.
     """
     pep_counts: dict[str, int] = {}
+    sampling_counts: dict[tuple, int] = {}
     total_spectra = 0
     for mgf_file in mgf_files:
         file_count = 0
@@ -96,23 +125,26 @@ def _collect_peptide_counts(
                     f"Missing 'seq' in spectrum params for spectrum "
                     f"{spectrum_index} in file {mgf_file}"
                 ) from exc
-            key = _canonical(seq)
-            pep_counts[key] = pep_counts.get(key, 0) + 1
+            pep_key = _canonical(seq)
+            pep_counts[pep_key] = pep_counts.get(pep_key, 0) + 1
+            samp_key = _sampling_key(spectrum)
+            sampling_counts[samp_key] = sampling_counts.get(samp_key, 0) + 1
             file_count += 1
         logging.info(f"Read {file_count} spectra from {mgf_file}.")
         total_spectra += file_count
 
     logging.info(f"Total spectra read: {total_spectra}")
     logging.info(f"Unique peptides: {len(pep_counts)}")
-    return pep_counts, total_spectra
+    return pep_counts, sampling_counts, total_spectra
 
 
 def _assign_splits(
     pep_counts: dict[str, int],
+    sampling_counts: dict[tuple, int],
     total_spectra: int,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
-    spectra_per_peptide: Optional[int],
-) -> tuple[dict[str, str], dict[str, set[int]], dict[str, set[str]]]:
+    spectra_per_precursor: Optional[int],
+) -> tuple[dict[str, str], dict[tuple, set[int]], dict[str, set[str]]]:
     """Compute per-peptide split assignments and sampling indices.
 
     Uses the global random state (caller must seed before calling).
@@ -121,42 +153,47 @@ def _assign_splits(
     ----------
     pep_counts : dict[str, int]
         Mapping of canonical peptide sequence to spectrum count from pass 1.
+        Used for split-proportion calculations (peptide-level).
+    sampling_counts : dict[tuple, int]
+        Mapping of ``(canonical_seq, charge_tuple)`` to spectrum count from
+        pass 1.  Used to cap spectra per (peptide, charge) combination.
     total_spectra : int
         Total spectra across all input files.
     existing_splits : tuple of PathLike or None
         Paths to existing train/val/test MGF files, or None.
-    spectra_per_peptide : int or None
-        Maximum spectra to retain per peptide, or None.
+    spectra_per_precursor : int or None
+        Maximum spectra to retain per (peptide, charge state), or None.
 
     Returns
     -------
     pep_to_split : dict[str, str]
         Mapping of canonical peptide sequence to split name
         ("train", "val", "test").
-    sampled_indices : dict[str, set[int]]
-        For peptides that exceed spectra_per_peptide, the 0-based indices
-        of spectra to retain. Empty dict if spectra_per_peptide is None.
+    sampled_indices : dict[tuple, set[int]]
+        For (peptide, charge) combinations that exceed spectra_per_precursor,
+        the 0-based indices of spectra to retain.  Empty dict if
+        spectra_per_precursor is None.
     existing_peps : dict[str, set[str]]
         Canonical peptides already present in each existing split. Empty sets
         if existing_splits is None.
     """
-    # Pre-compute which spectrum indices to keep for each peptide when
-    # spectra_per_peptide is set.
-    sampled_indices: dict[str, set[int]] = {}
-    if spectra_per_peptide is not None:
+    # Pre-compute which spectrum indices to keep for each (peptide, charge)
+    # when spectra_per_precursor is set.
+    sampled_indices: dict[tuple, set[int]] = {}
+    if spectra_per_precursor is not None:
         spectra_after = 0
-        for pep, count in pep_counts.items():
-            if count > spectra_per_peptide:
-                sampled_indices[pep] = set(
-                    random.sample(range(count), spectra_per_peptide)
+        for samp_key, count in sampling_counts.items():
+            if count > spectra_per_precursor:
+                sampled_indices[samp_key] = set(
+                    random.sample(range(count), spectra_per_precursor)
                 )
-                spectra_after += spectra_per_peptide
+                spectra_after += spectra_per_precursor
             else:
                 spectra_after += count
         eliminated = total_spectra - spectra_after
         logging.info(
-            f"Spectra eliminated by spectra_per_peptide="
-            f"{spectra_per_peptide}: {eliminated}"
+            f"Spectra eliminated by spectra_per_precursor="
+            f"{spectra_per_precursor}: {eliminated}"
         )
 
     # Handle existing splits if provided.
@@ -337,8 +374,8 @@ def _write_splits(
     mgf_files: tuple[PathLike, ...],
     output_root: str,
     pep_to_split: dict[str, str],
-    sampled_indices: dict[str, set[int]],
-    spectra_per_peptide: Optional[int],
+    sampled_indices: dict[tuple, set[int]],
+    spectra_per_precursor: Optional[int],
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]],
     combine_with_existing: bool,
 ) -> tuple[dict[str, int], dict[str, set[str]]]:
@@ -352,10 +389,10 @@ def _write_splits(
         Root path for output files.
     pep_to_split : dict[str, str]
         Mapping from canonical peptide sequence to split name.
-    sampled_indices : dict[str, set[int]]
-        Per-peptide sets of 0-based spectrum indices to retain.
-    spectra_per_peptide : int or None
-        Maximum spectra per peptide (used to check sampled_indices).
+    sampled_indices : dict[tuple, set[int]]
+        Per-(peptide, charge) sets of 0-based spectrum indices to retain.
+    spectra_per_precursor : int or None
+        Maximum spectra per (peptide, charge) (used to check sampled_indices).
     existing_splits : tuple of PathLike or None
         Paths to existing split files, required when combine_with_existing.
     combine_with_existing : bool
@@ -429,7 +466,7 @@ def _write_splits(
                     write_spectrum(split_name, spectrum)
 
         # Stream new input MGFs.
-        pep_counters: dict[str, int] = {}
+        pep_counters: dict[tuple, int] = {}
         for mgf_file in mgf_files:
             for spectrum in tqdm.tqdm(
                 pyteomics.mgf.read(str(mgf_file), use_index=False),
@@ -437,19 +474,20 @@ def _write_splits(
                 unit="PSM",
             ):
                 seq = spectrum["params"]["seq"]
-                key = _canonical(seq)
+                pep_key = _canonical(seq)
+                samp_key = _sampling_key(spectrum)
 
-                # Apply spectra_per_peptide filtering.
-                if spectra_per_peptide is not None:
-                    idx = pep_counters.get(key, 0)
-                    pep_counters[key] = idx + 1
-                    if key in sampled_indices:
-                        if idx not in sampled_indices[key]:
+                # Apply spectra_per_precursor filtering per (peptide, charge).
+                if spectra_per_precursor is not None:
+                    idx = pep_counters.get(samp_key, 0)
+                    pep_counters[samp_key] = idx + 1
+                    if samp_key in sampled_indices:
+                        if idx not in sampled_indices[samp_key]:
                             continue
-                    # If key not in sampled_indices, count <= limit,
+                    # If samp_key not in sampled_indices, count <= limit,
                     # so keep all.
 
-                split_name = pep_to_split.get(key)
+                split_name = pep_to_split.get(pep_key)
                 if split_name is not None:
                     write_spectrum(split_name, spectrum)
 
@@ -463,7 +501,7 @@ def _write_splits(
 def create_datasets(
     *mgf_files: PathLike,
     output_root: str,
-    spectra_per_peptide: Optional[int] = None,
+    spectra_per_precursor: Optional[int] = None,
     random_seed: int = 42,
     overwrite: bool = False,
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
@@ -501,10 +539,13 @@ def create_datasets(
         ``<output_root>.train.mgf``, ``<output_root>.val.mgf``, and
         ``<output_root>.test.mgf``. A log file ``<output_root>.log`` will
         also be created.
-    spectra_per_peptide : int, optional
+    spectra_per_precursor : int, optional
         If provided, randomly select at most this many spectra for each
-        peptide from the new input files. When ``combine_with_existing``
-        is True, existing spectra are not subject to this cap. By default
+        (peptide, precursor charge state) combination from the new input
+        files.  Spectra with the same sequence but different charge states
+        are treated independently, so each charge state may contribute up
+        to ``spectra_per_precursor`` spectra.  When ``combine_with_existing``
+        is True, existing spectra are not subject to this cap.  By default
         all spectra are retained.
     random_seed : int, default=42
         Random seed for reproducible splitting and sampling.
@@ -522,10 +563,10 @@ def create_datasets(
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
 
-    if spectra_per_peptide is not None and spectra_per_peptide <= 0:
+    if spectra_per_precursor is not None and spectra_per_precursor <= 0:
         raise ValueError(
-            f"spectra_per_peptide must be a positive integer, "
-            f"got {spectra_per_peptide}."
+            f"spectra_per_precursor must be a positive integer, "
+            f"got {spectra_per_precursor}."
         )
 
     if combine_with_existing and existing_splits is None:
@@ -551,13 +592,14 @@ def create_datasets(
 
     random.seed(random_seed)
 
-    pep_counts, total_spectra = _collect_peptide_counts(mgf_files)
+    pep_counts, sampling_counts, total_spectra = _collect_peptide_counts(mgf_files)
 
     pep_to_split, sampled_indices, existing_peps = _assign_splits(
         pep_counts,
+        sampling_counts,
         total_spectra,
         existing_splits,
-        spectra_per_peptide,
+        spectra_per_precursor,
     )
 
     split_spectra_counts, split_pep_sets = _write_splits(
@@ -565,7 +607,7 @@ def create_datasets(
         output_root,
         pep_to_split,
         sampled_indices,
-        spectra_per_peptide,
+        spectra_per_precursor,
         existing_splits,
         combine_with_existing,
     )

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -296,6 +296,13 @@ def _assign_splits(
                             f"existing split '{split_name}' from file "
                             f"'{split_path}'"
                         ) from exc
+                    if _MSKB_SEQ_RE.search(seq):
+                        raise ValueError(
+                            f"Existing split '{split_name}' ({split_path}) "
+                            f"appears to use MassIVE-KB PTM notation "
+                            f"(e.g. sequence {seq!r}). "
+                            f"existing_splits must be in ProForma format."
+                        )
                     existing_peps[split_name].add(_canonical(seq))
             logging.info(
                 f"Existing {split_name}: "
@@ -672,21 +679,6 @@ def create_datasets(
         raise ValueError(
             "combine_with_existing=True requires existing_splits to be provided."
         )
-
-    if existing_splits is not None:
-        split_names = ("train", "val", "test")
-        for split_name, split_path in zip(split_names, existing_splits):
-            with pyteomics.mgf.read(str(split_path), use_index=False) as reader:
-                for spectrum in reader:
-                    seq = spectrum["params"].get("seq", "")
-                    if seq and _MSKB_SEQ_RE.search(seq):
-                        raise ValueError(
-                            f"Existing split '{split_name}' ({split_path}) "
-                            f"appears to use MassIVE-KB PTM notation "
-                            f"(e.g. sequence {seq!r}). "
-                            f"existing_splits must be in ProForma format."
-                        )
-                    break  # Only check first spectrum per file.
 
     if not overwrite:
         expected_files = [

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -705,62 +705,72 @@ def create_datasets(
 
     configure_logging()
     log_file = pathlib.Path(f"{output_root}.log.txt")
-    file_handler = logging.FileHandler(log_file)
+    # Use mode="w" so log.txt is always a single-run artifact, consistent with
+    # overwrite semantics for the MGF and peptides.txt outputs.
+    file_handler = logging.FileHandler(log_file, mode="w")
     file_handler.setFormatter(
         logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
     )
     logging.root.addHandler(file_handler)
 
-    random.seed(random_seed)
+    try:
+        random.seed(random_seed)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        if mskb_format:
-            tmp = pathlib.Path(tmpdir)
-            converted = []
-            for i, src in enumerate(mgf_files):
-                src = pathlib.Path(src)
-                dst = tmp / f"converted_{i}_{src.name}"
-                logging.info(f"Converting {src} from MassIVE-KB format to ProForma...")
-                _mskb2proforma_convert(src, dst)
-                converted.append(dst)
-            mgf_files = tuple(converted)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            if mskb_format:
+                tmp = pathlib.Path(tmpdir)
+                converted = []
+                for i, src in enumerate(mgf_files):
+                    src = pathlib.Path(src)
+                    dst = tmp / f"converted_{i}_{src.name}"
+                    logging.info(
+                        f"Converting {src} from MassIVE-KB format to ProForma..."
+                    )
+                    _mskb2proforma_convert(src, dst)
+                    converted.append(dst)
+                mgf_files = tuple(converted)
 
-        pep_counts, sampling_counts, total_spectra = _collect_peptide_counts(mgf_files)
-
-        pep_to_split, sampled_indices, existing_peps = _assign_splits(
-            pep_counts,
-            sampling_counts,
-            total_spectra,
-            existing_splits,
-            spectra_per_precursor,
-        )
-
-        split_spectra_counts, split_pep_sets, mod_to_bare_by_split = _write_splits(
-            mgf_files,
-            output_root,
-            pep_to_split,
-            sampled_indices,
-            spectra_per_precursor,
-            existing_splits,
-            combine_with_existing,
-        )
-
-    # Log split summaries.
-    for split_name in ("train", "val", "test"):
-        peps = split_pep_sets[split_name]
-        count = split_spectra_counts[split_name]
-        if combine_with_existing:
-            new_pep_count = len(peps - existing_peps[split_name])
-            total_peps = len(peps | existing_peps[split_name])
-            logging.info(
-                f"{split_name}: {count} spectra, "
-                f"{new_pep_count} new peptides, "
-                f"{total_peps} total peptides"
+            pep_counts, sampling_counts, total_spectra = _collect_peptide_counts(
+                mgf_files
             )
-        else:
-            logging.info(f"{split_name}: {count} spectra, {len(peps)} peptides")
 
-    _write_peptides_txt(output_root, mod_to_bare_by_split)
+            pep_to_split, sampled_indices, existing_peps = _assign_splits(
+                pep_counts,
+                sampling_counts,
+                total_spectra,
+                existing_splits,
+                spectra_per_precursor,
+            )
+
+            split_spectra_counts, split_pep_sets, mod_to_bare_by_split = _write_splits(
+                mgf_files,
+                output_root,
+                pep_to_split,
+                sampled_indices,
+                spectra_per_precursor,
+                existing_splits,
+                combine_with_existing,
+            )
+
+        # Log split summaries.
+        for split_name in ("train", "val", "test"):
+            peps = split_pep_sets[split_name]
+            count = split_spectra_counts[split_name]
+            if combine_with_existing:
+                new_pep_count = len(peps - existing_peps[split_name])
+                total_peps = len(peps | existing_peps[split_name])
+                logging.info(
+                    f"{split_name}: {count} spectra, "
+                    f"{new_pep_count} new peptides, "
+                    f"{total_peps} total peptides"
+                )
+            else:
+                logging.info(f"{split_name}: {count} spectra, {len(peps)} peptides")
+
+        _write_peptides_txt(output_root, mod_to_bare_by_split)
+    finally:
+        logging.root.removeHandler(file_handler)
+        file_handler.close()
 
 
 COMMANDS: Commands = create_datasets

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -19,13 +19,13 @@ from .types import Commands
 # Number of spectra to buffer per output file before flushing to disk.
 _WRITE_BUFFER_SIZE = 1000
 
-# Matches a bracket-enclosed modification token and an optional trailing dash
-# (for N-terminal mods like "[Acetyl]-").
-_MOD_RE = re.compile(r"\[[^\]]*\]-?")
+# Matches a bracket-enclosed modification token with an optional leading or
+# trailing dash (N-terminal: "[Acetyl]-"; C-terminal: "-[Amidated]").
+_MOD_RE = re.compile(r"-?\[[^\]]*\]-?")
 
-# Matches MassIVE-KB PTM notation: a sign+decimal mass shift at the start of
-# a sequence (N-terminal) or immediately after a residue letter.
-_MSKB_SEQ_RE = re.compile(r"(?:^|[A-Z])[+-]\d+\.\d+")
+# Matches MassIVE-KB PTM notation: a sign+mass shift (integer or decimal) at
+# the start of a sequence (N-terminal) or immediately after a residue letter.
+_MSKB_SEQ_RE = re.compile(r"(?:^|[A-Z])[+-]\d+(?:\.\d+)?")
 
 
 def _canonical(seq: str) -> str:
@@ -663,8 +663,8 @@ def create_datasets(
         If False, only new spectra are written.
     mskb_format : bool, default=False
         If True, input MGF files are assumed to use MassIVE-KB PTM notation
-        and are converted to ProForma format before splitting. The output MGF
-        files always contain ProForma sequences.
+        and are converted to ProForma format before splitting. Conversion
+        raises a ``ValueError`` if any sequence cannot be converted.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -49,7 +49,19 @@ def _canonical(seq: str) -> str:
     str
         Canonical peptide sequence.
     """
-    seq = seq.replace("I", "L")
+    # Replace I with L only at residue positions (bracket depth 0), so that
+    # uppercase I characters inside modification names are left untouched.
+    chars = []
+    depth = 0
+    for ch in seq:
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+        elif ch == "I" and depth == 0:
+            ch = "L"
+        chars.append(ch)
+    seq = "".join(chars)
     seq = seq.replace("N[Deamidated]", "D")
     seq = seq.replace("Q[Deamidated]", "E")
     return seq

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -196,7 +196,11 @@ def convert(
         except Exception:
             tmp_path.unlink(missing_ok=True)
             raise
-    tmp_path.replace(output_file)
+    try:
+        tmp_path.replace(output_file)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
     logging.info("Converted %d spectra", n_converted)
 

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -3,6 +3,7 @@
 import logging
 import pathlib
 import re
+import tempfile
 from os import PathLike
 
 import fire
@@ -173,16 +174,29 @@ def convert(
                 ) from exc
         return {**spectrum, "params": params}
 
-    with pyteomics.mgf.read(
-        str(input_file), use_index=False, use_header=False
-    ) as reader:
+    output_file = pathlib.Path(output_file)
+    tmp_dir = output_file.parent
+    with (
+        pyteomics.mgf.read(
+            str(input_file), use_index=False, use_header=False
+        ) as reader,
+        tempfile.NamedTemporaryFile(
+            mode="w", dir=tmp_dir, suffix=".mgf", delete=False
+        ) as tmp_fh,
+    ):
+        tmp_path = pathlib.Path(tmp_fh.name)
         header = reader.header
         spectra = tqdm.tqdm(reader, desc="Converting spectra", unit="spectrum")
-        pyteomics.mgf.write(
-            (_convert_spectrum(s) for s in spectra),
-            output=str(output_file),
-            header=header,
-        )
+        try:
+            pyteomics.mgf.write(
+                (_convert_spectrum(s) for s in spectra),
+                output=tmp_fh,
+                header=header,
+            )
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+    tmp_path.replace(output_file)
 
     logging.info("Converted %d spectra", n_converted)
 

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -165,8 +165,10 @@ def convert(
                 params["seq"] = _convert_seq(original)
                 n_converted += 1
             except Exception as exc:
+                title = params.get("title", "<no title>")
                 raise ValueError(
-                    f"Could not convert sequence {original!r} in {input_file} "
+                    f"Could not convert sequence {original!r} "
+                    f"(spectrum title: {title!r}) in {input_file} "
                     f"to ProForma: {exc}"
                 ) from exc
         return {**spectrum, "params": params}

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -155,10 +155,9 @@ def convert(
     logging.info("Converting %s -> %s", input_file, output_file)
 
     n_converted = 0
-    n_skipped = 0
 
     def _convert_spectrum(spectrum: dict) -> dict:
-        nonlocal n_converted, n_skipped
+        nonlocal n_converted
         params = dict(spectrum["params"])
         if "seq" in params:
             original = params["seq"]
@@ -166,12 +165,9 @@ def convert(
                 params["seq"] = _convert_seq(original)
                 n_converted += 1
             except Exception as exc:
-                logging.warning(
-                    "Could not convert sequence %r: %s — keeping original",
-                    original,
-                    exc,
-                )
-                n_skipped += 1
+                raise ValueError(
+                    f"Could not convert sequence {original!r} to ProForma: {exc}"
+                ) from exc
         return {**spectrum, "params": params}
 
     with pyteomics.mgf.read(
@@ -186,11 +182,6 @@ def convert(
         )
 
     logging.info("Converted %d spectra", n_converted)
-    if n_skipped:
-        logging.warning(
-            "Skipped conversion for %d spectra (original SEQ retained)",
-            n_skipped,
-        )
 
 
 COMMANDS: Commands = convert

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -152,7 +152,7 @@ def convert(
             "Use --overwrite to overwrite."
         )
 
-    configure_logging(output_file.with_suffix(".log"))
+    file_handler = configure_logging(output_file.with_suffix(".log"))
     logging.info("Converting %s -> %s", input_file, output_file)
 
     n_converted = 0
@@ -174,34 +174,39 @@ def convert(
                 ) from exc
         return {**spectrum, "params": params}
 
-    output_file = pathlib.Path(output_file)
-    tmp_dir = output_file.parent
-    with tempfile.NamedTemporaryFile(
-        mode="w", dir=tmp_dir, suffix=".mgf", delete=False
-    ) as tmp_fh:
-        tmp_path = pathlib.Path(tmp_fh.name)
-    # tmp_fh is now closed; write via path so no handle is open during cleanup.
-    with pyteomics.mgf.read(
-        str(input_file), use_index=False, use_header=False
-    ) as reader:
-        header = reader.header
-        spectra = tqdm.tqdm(reader, desc="Converting spectra", unit="spectrum")
+    try:
+        output_file = pathlib.Path(output_file)
+        tmp_dir = output_file.parent
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=tmp_dir, suffix=".mgf", delete=False
+        ) as tmp_fh:
+            tmp_path = pathlib.Path(tmp_fh.name)
+        # tmp_fh is now closed; write via path so no handle is open during cleanup.
+        with pyteomics.mgf.read(
+            str(input_file), use_index=False, use_header=False
+        ) as reader:
+            header = reader.header
+            spectra = tqdm.tqdm(reader, desc="Converting spectra", unit="spectrum")
+            try:
+                pyteomics.mgf.write(
+                    (_convert_spectrum(s) for s in spectra),
+                    output=str(tmp_path),
+                    header=header,
+                )
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
         try:
-            pyteomics.mgf.write(
-                (_convert_spectrum(s) for s in spectra),
-                output=str(tmp_path),
-                header=header,
-            )
+            tmp_path.replace(output_file)
         except Exception:
             tmp_path.unlink(missing_ok=True)
             raise
-    try:
-        tmp_path.replace(output_file)
-    except Exception:
-        tmp_path.unlink(missing_ok=True)
-        raise
 
-    logging.info("Converted %d spectra", n_converted)
+        logging.info("Converted %d spectra", n_converted)
+    finally:
+        if file_handler is not None:
+            logging.root.removeHandler(file_handler)
+            file_handler.close()
 
 
 COMMANDS: Commands = convert

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -166,7 +166,8 @@ def convert(
                 n_converted += 1
             except Exception as exc:
                 raise ValueError(
-                    f"Could not convert sequence {original!r} to ProForma: {exc}"
+                    f"Could not convert sequence {original!r} in {input_file} "
+                    f"to ProForma: {exc}"
                 ) from exc
         return {**spectrum, "params": params}
 

--- a/src/casanovoutils/mskb2proforma.py
+++ b/src/casanovoutils/mskb2proforma.py
@@ -176,21 +176,20 @@ def convert(
 
     output_file = pathlib.Path(output_file)
     tmp_dir = output_file.parent
-    with (
-        pyteomics.mgf.read(
-            str(input_file), use_index=False, use_header=False
-        ) as reader,
-        tempfile.NamedTemporaryFile(
-            mode="w", dir=tmp_dir, suffix=".mgf", delete=False
-        ) as tmp_fh,
-    ):
+    with tempfile.NamedTemporaryFile(
+        mode="w", dir=tmp_dir, suffix=".mgf", delete=False
+    ) as tmp_fh:
         tmp_path = pathlib.Path(tmp_fh.name)
+    # tmp_fh is now closed; write via path so no handle is open during cleanup.
+    with pyteomics.mgf.read(
+        str(input_file), use_index=False, use_header=False
+    ) as reader:
         header = reader.header
         spectra = tqdm.tqdm(reader, desc="Converting spectra", unit="spectrum")
         try:
             pyteomics.mgf.write(
                 (_convert_spectrum(s) for s in spectra),
-                output=tmp_fh,
+                output=str(tmp_path),
                 header=header,
             )
         except Exception:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -889,7 +889,7 @@ class TestCreateDatasetsIsobaricNormalization:
         # Original sequences must appear in the output.
         assert "PEPTIDE" in all_seqs
         assert "REPTLDE" in all_seqs
-        # The canonical form should NOT appear in the output.
+        # Isobaric I/L variants of each input sequence must NOT appear in the output.
         assert "PEPTLDE" not in all_seqs
         assert "REPTIDE" not in all_seqs
 
@@ -1129,7 +1129,7 @@ class TestCreateDatasetsIsobaricNormalization:
 
 
 class TestCreateDatasetsEnhancements:
-    """Tests for peptides.txt output, log.txt output, and --mskb-format."""
+    """Tests for peptides.txt output, log.txt output, and --mskb_format."""
 
     # ------------------------------------------------------------------
     # _strip_mods unit tests

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -45,6 +45,34 @@ def _get_peptides(spectra):
     return [s["params"]["seq"] for s in spectra]
 
 
+def _write_mgf_with_charges(path, spectra):
+    """Write spectra including charge fields.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Output file path.
+    spectra : list[tuple[str, int, list[float], list[float]]]
+        Each element is (peptide_sequence, charge, mz_values, intensity_values).
+
+    Returns
+    -------
+    str
+        The string path to the written file.
+    """
+    records = []
+    for seq, charge, mz, intensity in spectra:
+        records.append(
+            {
+                "params": {"seq": seq, "pepmass": (100.0,), "charge": [charge]},
+                "m/z array": np.array(mz),
+                "intensity array": np.array(intensity),
+            }
+        )
+    pyteomics.mgf.write(records, output=str(path))
+    return str(path)
+
+
 class TestCreateDatasetsBasic:
     """Basic functionality tests for create_datasets."""
 
@@ -146,10 +174,10 @@ class TestCreateDatasetsMultipleFiles:
         assert any(p.startswith("PEPB") for p in all_peps)
 
 
-class TestCreateDatasetsSpectraPerPeptide:
-    """Tests for the spectra_per_peptide option."""
+class TestCreateDatasetsSpectraPerPrecursor:
+    """Tests for the spectra_per_precursor option."""
 
-    def test_limits_spectra_per_peptide(self, tmp_path):
+    def test_limits_spectra_per_precursor(self, tmp_path):
         """Each peptide should have at most k spectra in the output."""
         spectra = []
         for i in range(10):
@@ -161,7 +189,7 @@ class TestCreateDatasetsSpectraPerPeptide:
         create_datasets(
             mgf,
             output_root=output_root,
-            spectra_per_peptide=2,
+            spectra_per_precursor=2,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -178,7 +206,7 @@ class TestCreateDatasetsSpectraPerPeptide:
             assert count <= 2, f"{pep} has {count} spectra, expected <= 2"
 
     def test_no_limit_keeps_all_spectra(self, tmp_path):
-        """Without spectra_per_peptide, all spectra are retained."""
+        """Without spectra_per_precursor, all spectra are retained."""
         spectra = []
         for i in range(10):
             for _ in range(5):
@@ -194,7 +222,7 @@ class TestCreateDatasetsSpectraPerPeptide:
 
         assert len(train) + len(val) + len(test) == 50
 
-    def test_spectra_per_peptide_with_fewer_available(self, tmp_path):
+    def test_spectra_per_precursor_with_fewer_available(self, tmp_path):
         """Peptides with fewer than k spectra keep all of them."""
         spectra = [
             ("PEPA", [100.0], [1.0]),
@@ -211,7 +239,7 @@ class TestCreateDatasetsSpectraPerPeptide:
         create_datasets(
             mgf,
             output_root=output_root,
-            spectra_per_peptide=5,
+            spectra_per_precursor=5,
         )
 
         train = _read_mgf(tmp_path / "out.train.mgf")
@@ -226,6 +254,33 @@ class TestCreateDatasetsSpectraPerPeptide:
 
         assert pep_counts.get("PEPA", 0) == 1
         assert pep_counts.get("PEPB", 0) == 3
+
+    def test_spectra_per_precursor_per_charge_state(self, tmp_path):
+        """spectra_per_precursor=1 keeps one spectrum per (peptide, charge) pair."""
+        # PEPA appears 3 times with charge 2 and 3 times with charge 3.
+        # With spectra_per_precursor=1, we expect 1 spectrum at charge 2 AND
+        # 1 spectrum at charge 3 — 2 spectra total for PEPA, not 1.
+        spectra = []
+        for _ in range(3):
+            spectra.append(("PEPA", 2, [100.0], [1.0]))
+        for _ in range(3):
+            spectra.append(("PEPA", 3, [100.0], [1.0]))
+        # Add enough other peptides to form valid splits.
+        for i in range(18):
+            spectra.append((f"OTHER{i}", 2, [100.0], [1.0]))
+        mgf = _write_mgf_with_charges(tmp_path / "input.mgf", spectra)
+
+        create_datasets(mgf, output_root=str(tmp_path / "out"), spectra_per_precursor=1)
+
+        all_spectra = []
+        for split in ("train", "val", "test"):
+            all_spectra.extend(_read_mgf(tmp_path / f"out.{split}.mgf"))
+
+        pepa_spectra = [s for s in all_spectra if s["params"]["seq"] == "PEPA"]
+        # One spectrum per charge state → 2 total.
+        assert len(pepa_spectra) == 2
+        charges = {tuple(s["params"].get("charge", [])) for s in pepa_spectra}
+        assert charges == {(2,), (3,)}
 
 
 class TestCreateDatasetsReproducibility:
@@ -329,26 +384,30 @@ class TestCreateDatasetsEdgeCases:
                 existing_splits=(split, split),
             )
 
-    def test_spectra_per_peptide_zero_raises_error(self, tmp_path):
-        """Passing spectra_per_peptide=0 should raise a ValueError."""
+    def test_spectra_per_precursor_zero_raises_error(self, tmp_path):
+        """Passing spectra_per_precursor=0 should raise a ValueError."""
         mgf = _write_mgf(
             tmp_path / "input.mgf",
             [("PEP0", [100.0], [1.0])],
         )
-        with pytest.raises(ValueError, match="spectra_per_peptide must be a positive"):
+        with pytest.raises(
+            ValueError, match="spectra_per_precursor must be a positive"
+        ):
             create_datasets(
-                mgf, output_root=str(tmp_path / "out"), spectra_per_peptide=0
+                mgf, output_root=str(tmp_path / "out"), spectra_per_precursor=0
             )
 
-    def test_spectra_per_peptide_negative_raises_error(self, tmp_path):
-        """Passing a negative spectra_per_peptide should raise a ValueError."""
+    def test_spectra_per_precursor_negative_raises_error(self, tmp_path):
+        """Passing a negative spectra_per_precursor should raise a ValueError."""
         mgf = _write_mgf(
             tmp_path / "input.mgf",
             [("PEP0", [100.0], [1.0])],
         )
-        with pytest.raises(ValueError, match="spectra_per_peptide must be a positive"):
+        with pytest.raises(
+            ValueError, match="spectra_per_precursor must be a positive"
+        ):
             create_datasets(
-                mgf, output_root=str(tmp_path / "out"), spectra_per_peptide=-1
+                mgf, output_root=str(tmp_path / "out"), spectra_per_precursor=-1
             )
 
     def test_small_dataset_all_go_to_train(self, tmp_path):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -384,6 +384,31 @@ class TestCreateDatasetsEdgeCases:
                 existing_splits=(split, split),
             )
 
+    def test_existing_splits_mskb_notation_raises_error(self, tmp_path):
+        """existing_splits containing MassIVE-KB PTM notation should raise ValueError."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [("PEP0", [100.0], [1.0])],
+        )
+        # Write a split MGF with a MassIVE-KB-style sequence (mass shift notation).
+        mskb_split = tmp_path / "mskb_split.mgf"
+        pyteomics.mgf.write(
+            [
+                {
+                    "params": {"seq": "C+57.021PEPTIDE", "pepmass": (900.0,)},
+                    "m/z array": np.array([100.0]),
+                    "intensity array": np.array([1.0]),
+                }
+            ],
+            output=str(mskb_split),
+        )
+        with pytest.raises(ValueError, match="MassIVE-KB"):
+            create_datasets(
+                mgf,
+                output_root=str(tmp_path / "out"),
+                existing_splits=(mskb_split, mskb_split, mskb_split),
+            )
+
     def test_spectra_per_precursor_zero_raises_error(self, tmp_path):
         """Passing spectra_per_precursor=0 should raise a ValueError."""
         mgf = _write_mgf(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -178,7 +178,7 @@ class TestCreateDatasetsSpectraPerPrecursor:
     """Tests for the spectra_per_precursor option."""
 
     def test_limits_spectra_per_precursor(self, tmp_path):
-        """Each peptide should have at most k spectra in the output."""
+        """Each (peptide, charge state) precursor should have at most k spectra in the output."""
         spectra = []
         for i in range(10):
             for _ in range(5):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -174,7 +174,7 @@ class TestCreateDatasetsMultipleFiles:
         assert any(p.startswith("PEPB") for p in all_peps)
 
 
-class TestCreateDatasetsSpectraPerPrecursor:
+class TestCreateDatasetsSpectraPerPeptide:
     """Tests for the spectra_per_precursor option."""
 
     def test_limits_spectra_per_precursor(self, tmp_path):
@@ -848,7 +848,7 @@ class TestCreateDatasetsIsobaricNormalization:
 
     def test_original_sequences_preserved_in_output(self, tmp_path):
         """Output MGF files retain original sequences despite isobaric normalization."""
-        spectra = [("PEPTIDE", [100.0], [1.0]), ("PEPTLDE", [100.0], [1.0])]
+        spectra = [("PEPTIDE", [100.0], [1.0]), ("REPTLDE", [100.0], [1.0])]
         for i in range(28):
             spectra.append((f"OTHER{i}", [100.0], [1.0]))
         mgf = _write_mgf(tmp_path / "input.mgf", spectra)
@@ -861,9 +861,12 @@ class TestCreateDatasetsIsobaricNormalization:
         test = _read_mgf(tmp_path / "out.test.mgf")
 
         all_seqs = set(_get_peptides(train + val + test))
-        # Original sequences (not their canonical forms) must be preserved.
+        # Original sequences must appear in the output.
         assert "PEPTIDE" in all_seqs
-        assert "PEPTLDE" in all_seqs
+        assert "REPTLDE" in all_seqs
+        # The canonical form should NOT appear in the output.
+        assert "PEPTLDE" not in all_seqs
+        assert "REPTIDE" not in all_seqs
 
     def test_il_normalization_with_existing_splits(self, tmp_path):
         """I/L variant in new data routes to the correct existing split."""
@@ -1098,3 +1101,207 @@ class TestCreateDatasetsIsobaricNormalization:
         ), "N[Deamidated]-form should follow D-form into train"
         assert "PEPTN[Deamidated]DE" not in val_seqs
         assert "PEPTN[Deamidated]DE" not in test_seqs
+
+
+class TestCreateDatasetsEnhancements:
+    """Tests for peptides.txt output, log.txt output, and --mskb-format."""
+
+    # ------------------------------------------------------------------
+    # _strip_mods unit tests
+    # ------------------------------------------------------------------
+
+    def test_strip_mods_no_mods(self):
+        """Bare sequences are returned unchanged."""
+        from casanovoutils.datasets import _strip_mods
+
+        assert _strip_mods("PEPTIDE") == "PEPTIDE"
+
+    def test_strip_mods_per_residue(self):
+        """Per-residue modification brackets are removed."""
+        from casanovoutils.datasets import _strip_mods
+
+        assert _strip_mods("AC[Carbamidomethyl]GK") == "ACGK"
+        assert _strip_mods("AM[Oxidation]G") == "AMG"
+        assert _strip_mods("AN[Deamidated]G") == "ANG"
+
+    def test_strip_mods_nterm(self):
+        """N-terminal modification token including trailing dash is removed."""
+        from casanovoutils.datasets import _strip_mods
+
+        assert _strip_mods("[Acetyl]-PEPTIDE") == "PEPTIDE"
+        assert _strip_mods("[+229.163]-PEPTIDEK") == "PEPTIDEK"
+
+    def test_strip_mods_combined(self):
+        """Mixed N-terminal and per-residue mods are all removed."""
+        from casanovoutils.datasets import _strip_mods
+
+        assert _strip_mods("[+271.174]-AC[Carbamidomethyl]GK[+229.163]") == "ACGK"
+
+    # ------------------------------------------------------------------
+    # peptides.txt output
+    # ------------------------------------------------------------------
+
+    def test_peptides_txt_files_created(self, tmp_path):
+        """A peptides.txt file is created for each split."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [(f"PEP{i}", [100.0], [1.0]) for i in range(20)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"))
+
+        for split in ("train", "val", "test"):
+            assert (tmp_path / f"out.{split}.peptides.txt").exists()
+
+    def test_peptides_txt_two_columns(self, tmp_path):
+        """peptides.txt has two tab-separated columns: modified and bare."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [
+                ("AC[Carbamidomethyl]GK", [100.0], [1.0]),
+                ("[Acetyl]-PEPTIDE", [100.0], [1.0]),
+            ]
+            + [(f"OTHER{i}", [100.0], [1.0]) for i in range(18)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"))
+
+        all_rows: list[tuple[str, str]] = []
+        for split in ("train", "val", "test"):
+            lines = (tmp_path / f"out.{split}.peptides.txt").read_text().splitlines()
+            for line in lines:
+                cols = line.split("\t")
+                assert len(cols) == 2, f"Expected 2 columns, got {len(cols)}: {line!r}"
+                all_rows.append((cols[0], cols[1]))
+
+        modified_seqs = {r[0] for r in all_rows}
+        bare_seqs = {r[1] for r in all_rows}
+
+        # Modified column preserves the full ProForma sequence.
+        assert "AC[Carbamidomethyl]GK" in modified_seqs
+        assert "[Acetyl]-PEPTIDE" in modified_seqs
+        # Bare column applies canonical substitutions then strips mods.
+        # PEPTIDE contains I → L, so bare form is PEPTLDE.
+        assert "ACGK" in bare_seqs
+        assert "PEPTLDE" in bare_seqs
+        # No brackets in the bare column.
+        for bare in bare_seqs:
+            assert "[" not in bare, f"Bracket found in bare column: {bare!r}"
+
+    def test_peptides_txt_canonical_bare(self, tmp_path):
+        """Bare column applies isobaric substitutions (I→L, N[Deamidated]→D, Q[Deamidated]→E)."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [
+                ("AN[Deamidated]G", [100.0], [1.0]),
+                ("AQ[Deamidated]G", [100.0], [1.0]),
+                ("AIKG", [100.0], [1.0]),
+            ]
+            + [(f"OTHER{i}", [100.0], [1.0]) for i in range(17)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"))
+
+        all_rows: list[tuple[str, str]] = []
+        for split in ("train", "val", "test"):
+            lines = (tmp_path / f"out.{split}.peptides.txt").read_text().splitlines()
+            for line in lines:
+                cols = line.split("\t")
+                all_rows.append((cols[0], cols[1]))
+
+        bare_by_modified = dict(all_rows)
+        # N[Deamidated] → D in bare column.
+        assert bare_by_modified.get("AN[Deamidated]G") == "ADG"
+        # Q[Deamidated] → E in bare column.
+        assert bare_by_modified.get("AQ[Deamidated]G") == "AEG"
+        # I → L in bare column.
+        assert bare_by_modified.get("AIKG") == "ALKG"
+
+    def test_peptides_txt_sorted(self, tmp_path):
+        """peptides.txt rows are sorted by bare sequence then modified sequence."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [(f"PEP{i:02d}", [100.0], [1.0]) for i in range(20)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"))
+
+        for split in ("train", "val", "test"):
+            lines = (tmp_path / f"out.{split}.peptides.txt").read_text().splitlines()
+            rows = [line.split("\t") for line in lines]
+            keys = [(r[1], r[0]) for r in rows]
+            assert keys == sorted(keys), f"{split} peptides.txt is not sorted"
+
+    def test_peptides_txt_unique(self, tmp_path):
+        """peptides.txt has one row per unique modified sequence."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [("PEPTIDE", [100.0], [1.0])] * 5
+            + [(f"OTHER{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"))
+
+        all_modified: list[str] = []
+        for split in ("train", "val", "test"):
+            lines = (tmp_path / f"out.{split}.peptides.txt").read_text().splitlines()
+            all_modified += [line.split("\t")[0] for line in lines]
+
+        assert all_modified.count("PEPTIDE") == 1
+
+    # ------------------------------------------------------------------
+    # --mskb-format
+    # ------------------------------------------------------------------
+
+    def test_mskb_format_converts_sequences(self, tmp_path):
+        """mskb_format=True converts MassIVE-KB sequences to ProForma in output."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [("C+57.021PEPTIDE", [100.0], [1.0])]
+            + [(f"OTHER{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"), mskb_format=True)
+
+        all_seqs: set[str] = set()
+        for split in ("train", "val", "test"):
+            all_seqs.update(_get_peptides(_read_mgf(tmp_path / f"out.{split}.mgf")))
+
+        assert "C[Carbamidomethyl]PEPTIDE" in all_seqs
+        assert "C+57.021PEPTIDE" not in all_seqs
+
+    def test_mskb_format_nterm_converted(self, tmp_path):
+        """mskb_format=True sums and converts combined N-terminal shifts."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [("+42.011PEPTIDE", [100.0], [1.0])]
+            + [(f"OTHER{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"), mskb_format=True)
+
+        all_seqs: set[str] = set()
+        for split in ("train", "val", "test"):
+            all_seqs.update(_get_peptides(_read_mgf(tmp_path / f"out.{split}.mgf")))
+
+        assert "[Acetyl]-PEPTIDE" in all_seqs
+        assert "+42.011PEPTIDE" not in all_seqs
+
+    def test_mskb_format_peptides_txt_columns(self, tmp_path):
+        """With mskb_format=True, peptides.txt has ProForma in col 1 and bare in col 2."""
+        mgf = _write_mgf(
+            tmp_path / "input.mgf",
+            [("C+57.021PEPTIDE", [100.0], [1.0])]
+            + [(f"OTHER{i}", [100.0], [1.0]) for i in range(19)],
+        )
+        create_datasets(mgf, output_root=str(tmp_path / "out"), mskb_format=True)
+
+        all_rows: list[tuple[str, str]] = []
+        for split in ("train", "val", "test"):
+            lines = (tmp_path / f"out.{split}.peptides.txt").read_text().splitlines()
+            for line in lines:
+                cols = line.split("\t")
+                assert len(cols) == 2
+                all_rows.append((cols[0], cols[1]))
+
+        modified_seqs = {r[0] for r in all_rows}
+        bare_seqs = {r[1] for r in all_rows}
+
+        assert "C[Carbamidomethyl]PEPTIDE" in modified_seqs
+        # CPEPTIDE contains I → L, so bare form is CPEPTLDE.
+        assert "CPEPTLDE" in bare_seqs
+        for bare in bare_seqs:
+            assert "[" not in bare

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -174,7 +174,7 @@ class TestCreateDatasetsMultipleFiles:
         assert any(p.startswith("PEPB") for p in all_peps)
 
 
-class TestCreateDatasetsSpectraPerPeptide:
+class TestCreateDatasetsSpectraPerPrecursor:
     """Tests for the spectra_per_precursor option."""
 
     def test_limits_spectra_per_precursor(self, tmp_path):


### PR DESCRIPTION
## Summary

- After pass 1, logs now report three levels of sequence/peptide objects in order:
  1. **Unique raw sequences** — distinct `seq` strings exactly as they appear in the input MGFs
  2. **Unique canonical peptides** — after I/L and deamidation collapsing, with a count of how many sequences were merged
  3. **Unique precursors (sequence + charge state)** — distinct `(canonical_seq, charge)` combinations
- When `spectra_per_precursor` is set, also logs how many precursors exceeded the cap and how many spectra were retained (not just eliminated)
- After split assignment, logs the canonical peptide count per split

## Test plan

- [ ] All existing tests pass
- [ ] Verify log output manually with a small MGF containing I/L synonyms and deamidated peptides

🤖 Generated with [Claude Code](https://claude.ai/claude-code)