### PR TITLE
Add CodeRabbit config: review PRs targeting main or dev

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  base_branches:
+    - "main"
+    - "dev"


### PR DESCRIPTION
Adds `.coderabbit.yaml` so CodeRabbit reviews PRs targeting either `main` or `dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration for the main development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->