### PR TITLE
Add count-cterm-aas subcommand to summarize_mgf

### DIFF
--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -311,7 +311,8 @@ Generate per-file statistics and visualisations for MGF files.
 ### `summarize`
 
 Produce a self-contained HTML report for an MGF file covering charge
-distribution, peak counts, peptide lengths, and fragment ion coverage.
+distribution, peak counts, peptide lengths, C-terminal amino acid distribution,
+and fragment ion coverage.
 
 | Argument | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -328,6 +329,28 @@ distribution, peak counts, peptide lengths, and fragment ion coverage.
 ```bash
 casanovoutils summarize_mgf summarize input.mgf --output_root my_report \
   --tolerance 10 --tolerance_unit ppm --workers 4
+```
+
+---
+
+### `count-cterm-aas`
+
+Count C-terminal amino acid residues across annotated spectra (requires `SEQ=`).
+Counts at PSM level (one tally per spectrum, not per unique peptide).  The full
+residue token is reported, so a modified residue such as `K[+229.163]` is
+counted separately from bare `K`.  Spectra without `SEQ=` are skipped.
+
+| Argument | Type | Default | Description |
+| --- | --- | --- | --- |
+| `mgf_file` | path | required | Input MGF file (requires `SEQ=` in ProForma notation) |
+| `--output_tsv` | path | `"cterm_aas.tsv"` | Output counts TSV (`amino_acid`, `count`, `percentage`) |
+| `--output_plot` | path | `"cterm_aas.png"` | Output horizontal bar chart |
+
+**Example:**
+
+```bash
+casanovoutils summarize_mgf count-cterm-aas input.mgf \
+  --output_tsv cterm.tsv --output_plot cterm.png
 ```
 
 ---

--- a/src/casanovoutils/summarize_mgf.py
+++ b/src/casanovoutils/summarize_mgf.py
@@ -99,7 +99,7 @@ def _make_cterm_bar_fig(counts: Counter) -> plt.Figure:
     total = sum(counts.values())
     tokens = sorted(counts, key=lambda t: -counts[t])
     vals = [counts[t] for t in tokens]
-    fig, ax = plt.subplots(figsize=(7, max(3, 0.4 * len(tokens))))
+    fig, ax = plt.subplots(figsize=(7, min(max(3, 0.4 * len(tokens)), 12)))
     ax.barh(tokens[::-1], vals[::-1], edgecolor="black", linewidth=0.5)
     ax.set_xlabel("Number of PSMs")
     ax.set_ylabel("C-terminal residue")

--- a/src/casanovoutils/summarize_mgf.py
+++ b/src/casanovoutils/summarize_mgf.py
@@ -505,13 +505,19 @@ def count_cterm_aas(spectra: Iterable) -> tuple[Counter, int]:
     counts : Counter[str]
         Mapping of C-terminal residue token to PSM count.
     n_skipped : int
-        Number of spectra skipped (missing or unparseable ``SEQ=``).
+        Number of spectra skipped (missing ``SEQ=``, invalid ProForma, or
+        unrecognisable C-terminal token).
     """
     counts: Counter[str] = Counter()
     n_skipped = 0
     for spectrum in spectra:
         seq = spectrum["params"].get("seq", "")
         if not seq:
+            n_skipped += 1
+            continue
+        try:
+            pyteomics_proforma.parse(seq)
+        except Exception:
             n_skipped += 1
             continue
         token = _extract_cterm_token(seq)
@@ -550,8 +556,8 @@ def cterm_aa_distribution(
     print(f"Processed {total + n_skipped} spectra total.", file=sys.stderr)
     if n_skipped:
         print(
-            f"  Warning: {n_skipped} spectra without SEQ= or with unparseable"
-            " sequences were skipped.",
+            f"  Warning: {n_skipped} spectra without SEQ= or with invalid"
+            " ProForma sequences were skipped.",
             file=sys.stderr,
         )
 
@@ -1245,11 +1251,6 @@ def summarize_mgf(
 
                     n_with_seq += 1
 
-                    # C-terminal residue token (lightweight, no parse needed)
-                    cterm_token = _extract_cterm_token(seq)
-                    if cterm_token is not None:
-                        cterm_counts[cterm_token] += 1
-
                     try:
                         parsed_seq, props = pyteomics_proforma.parse(seq)
                         length_counts[len(parsed_seq)] += 1
@@ -1260,6 +1261,10 @@ def summarize_mgf(
                             mod_counts[("N-term", str(mod))] += 1
                         for mod in props.get("c_term") or []:
                             mod_counts[("C-term", str(mod))] += 1
+                        # C-terminal residue token (only for valid ProForma seqs)
+                        cterm_token = _extract_cterm_token(seq)
+                        if cterm_token is not None:
+                            cterm_counts[cterm_token] += 1
                     except Exception:
                         n_parse_errors += 1
 

--- a/src/casanovoutils/summarize_mgf.py
+++ b/src/casanovoutils/summarize_mgf.py
@@ -456,6 +456,14 @@ def peptide_lengths(
             file=sys.stderr,
         )
 
+    if not lengths:
+        print(
+            "Error: no spectra with valid SEQ= in ProForma notation found."
+            " Nothing to output.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     counts_map = Counter(lengths)
 
     # -- TSV output (sorted by length) ----------------------------------------
@@ -906,6 +914,15 @@ def fragment_coverage(
     count = len(results) + n_skipped
     print(f"Processed {count} spectra total.", file=sys.stderr)
     print(f"  {len(results)} scored, {n_skipped} skipped.", file=sys.stderr)
+
+    if not results:
+        print(
+            "Error: no spectra could be scored (all were skipped due to"
+            " missing SEQ=, invalid ProForma, or missing/ambiguous charge)."
+            " Nothing to output.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # -- Full per-spectrum TSV (in input order) --------------------------------
     with open(output_full_tsv, "w", newline="") as fh:

--- a/src/casanovoutils/summarize_mgf.py
+++ b/src/casanovoutils/summarize_mgf.py
@@ -46,6 +46,7 @@ Requires: pyteomics, spectrum_utils, numpy, matplotlib
 import csv
 import html as html_mod
 import os
+import re
 import sys
 from collections import Counter
 from concurrent.futures import ProcessPoolExecutor
@@ -89,6 +90,20 @@ def _make_charge_fig(counts: dict) -> plt.Figure:
     ax.set_xlabel("Charge state")
     ax.set_ylabel("Number of spectra")
     ax.set_title(f"Charge state distribution (n={total:,})")
+    fig.tight_layout()
+    return fig
+
+
+def _make_cterm_bar_fig(counts: Counter) -> plt.Figure:
+    """Create a horizontal bar chart for C-terminal amino acid counts."""
+    total = sum(counts.values())
+    tokens = sorted(counts, key=lambda t: -counts[t])
+    vals = [counts[t] for t in tokens]
+    fig, ax = plt.subplots(figsize=(7, max(3, 0.4 * len(tokens))))
+    ax.barh(tokens[::-1], vals[::-1], edgecolor="black", linewidth=0.5)
+    ax.set_xlabel("Number of PSMs")
+    ax.set_ylabel("C-terminal residue")
+    ax.set_title(f"C-terminal amino acid distribution (n={total:,})")
     fig.tight_layout()
     return fig
 
@@ -179,6 +194,43 @@ def _median_from_bins(bin_counts: np.ndarray, bin_edges: np.ndarray) -> float:
         if cumsum >= mid:
             return float((bin_edges[i] + bin_edges[i + 1]) / 2)
     return float((bin_edges[-2] + bin_edges[-1]) / 2)
+
+
+# ---------------------------------------------------------------------------
+# C-terminal token extraction
+# ---------------------------------------------------------------------------
+
+# Matches a trailing ProForma C-terminal sequence tag, e.g. "-[Amidated]".
+_CTERM_TAG_RE = re.compile(r"-\[[^\]]*\]$")
+
+# Matches the last residue token in a ProForma sequence: an uppercase letter
+# optionally followed by one or more bracketed modification labels,
+# e.g. "K", "K[+229.163]", "K[Acetyl][+229.163]".
+_LAST_RESIDUE_RE = re.compile(r"([A-Z](?:\[[^\]]*\])*)$")
+
+
+def _extract_cterm_token(seq: str) -> str | None:
+    """Return the C-terminal residue token from a ProForma sequence string.
+
+    Includes any modification labels attached to that residue (e.g.
+    ``"K[+229.163]"``).  C-terminal sequence tags (``"-[mod]"``) are
+    stripped before extraction.  Returns ``None`` if the sequence is empty
+    or the last token cannot be identified.
+
+    Parameters
+    ----------
+    seq : str
+        Peptide sequence in ProForma notation.
+
+    Returns
+    -------
+    str or None
+        The last residue token, e.g. ``"K"``, ``"K[+229.163]"``, or
+        ``None`` if extraction fails.
+    """
+    seq = _CTERM_TAG_RE.sub("", seq)
+    m = _LAST_RESIDUE_RE.search(seq)
+    return m.group(1) if m else None
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +479,94 @@ def peptide_lengths(
             title=title,
             integer_bins=True,
         )
+        fig.savefig(output_plot, dpi=150)
+        plt.close(fig)
+        print(f"Wrote {output_plot}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# C-terminal amino acid distribution
+# ---------------------------------------------------------------------------
+
+
+def count_cterm_aas(spectra: Iterable) -> tuple[Counter, int]:
+    """Count C-terminal residue tokens across annotated spectra at PSM level.
+
+    The full residue token is used, including any modification label (e.g.
+    ``"K[+229.163]"`` is tallied separately from ``"K"``).
+
+    Parameters
+    ----------
+    spectra : Iterable
+        Iterable of pyteomics spectrum dicts.
+
+    Returns
+    -------
+    counts : Counter[str]
+        Mapping of C-terminal residue token to PSM count.
+    n_skipped : int
+        Number of spectra skipped (missing or unparseable ``SEQ=``).
+    """
+    counts: Counter[str] = Counter()
+    n_skipped = 0
+    for spectrum in spectra:
+        seq = spectrum["params"].get("seq", "")
+        if not seq:
+            n_skipped += 1
+            continue
+        token = _extract_cterm_token(seq)
+        if token is None:
+            n_skipped += 1
+            continue
+        counts[token] += 1
+    return counts, n_skipped
+
+
+def cterm_aa_distribution(
+    mgf_file: PathLike,
+    output_tsv: PathLike = "cterm_aas.tsv",
+    output_plot: PathLike = "cterm_aas.png",
+) -> None:
+    """C-terminal amino acid distribution for annotated spectra in an MGF file.
+
+    Counts at PSM level (one tally per spectrum, not per unique peptide).
+    The full residue token is used, including any modification label (e.g.
+    ``K[+229.163]`` is counted separately from ``K``).  Spectra without a
+    ``SEQ=`` field are skipped.
+
+    Parameters
+    ----------
+    mgf_file : PathLike
+        Input MGF file (requires ``SEQ=`` in ProForma notation).
+    output_tsv : PathLike
+        Output TSV path (default: cterm_aas.tsv).
+    output_plot : PathLike
+        Output horizontal bar chart path (default: cterm_aas.png).
+    """
+    with mgf.MGF(mgf_file) as reader:
+        counts, n_skipped = count_cterm_aas(reader)
+
+    total = sum(counts.values())
+    print(f"Processed {total + n_skipped} spectra total.", file=sys.stderr)
+    if n_skipped:
+        print(
+            f"  Warning: {n_skipped} spectra without SEQ= or with unparseable"
+            " sequences were skipped.",
+            file=sys.stderr,
+        )
+
+    # -- TSV output (sorted by count descending) ------------------------------
+    with open(output_tsv, "w", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(["amino_acid", "count", "percentage"])
+        for token in sorted(counts, key=lambda t: -counts[t]):
+            pct = 100.0 * counts[token] / total if total else 0.0
+            w.writerow([token, counts[token], f"{pct:.2f}"])
+    print(f"Wrote {output_tsv}", file=sys.stderr)
+
+    # -- Bar chart ------------------------------------------------------------
+    if counts:
+        fig = _make_cterm_bar_fig(counts)
         fig.savefig(output_plot, dpi=150)
         plt.close(fig)
         print(f"Wrote {output_plot}", file=sys.stderr)
@@ -823,6 +963,8 @@ def _build_summary_html(
     coverage_png: str | None,
     coverage_stats: dict | None,
     mod_counts: Counter | None = None,
+    cterm_counts: Counter | None = None,
+    cterm_png: str | None = None,
     tolerance: float = 0.05,
     tolerance_unit: str = "Da",
     max_charge: str = "1less",
@@ -896,6 +1038,21 @@ def _build_summary_html(
             lengths_html = "<p class='note'>No annotated spectra.</p>"
         lengths_section = f"<h2>Peptide Lengths</h2>{lengths_html}{_img(lengths_png)}"
 
+    cterm_section = ""
+    if cterm_png is not None and cterm_counts:
+        total_cterm = sum(cterm_counts.values())
+        cterm_rows = sorted(cterm_counts.items(), key=lambda x: -x[1])
+        cterm_table = _table(
+            ["Residue", "Count", "Percentage"],
+            [
+                (token, f"{count:,}", f"{100.0 * count / total_cterm:.2f}%")
+                for token, count in cterm_rows
+            ],
+        )
+        cterm_section = (
+            f"<h2>C-terminal Amino Acids</h2>" f"{cterm_table}" f"{_img(cterm_png)}"
+        )
+
     coverage_section = ""
     if coverage_png is not None:
         max_charge_label = (
@@ -962,6 +1119,7 @@ def _build_summary_html(
 {peaks_html}
 {peaks_img}
 {lengths_section}
+{cterm_section}
 {coverage_section}
 </body>
 </html>"""
@@ -1054,6 +1212,7 @@ def summarize_mgf(
             charge_counts: Counter[int] = Counter()
             peak_counts_counter: Counter[int] = Counter()
             length_counts: Counter[int] = Counter()
+            cterm_counts: Counter[str] = Counter()
 
             mod_counts: Counter[tuple[str, str]] = Counter()
 
@@ -1085,6 +1244,12 @@ def summarize_mgf(
                         continue
 
                     n_with_seq += 1
+
+                    # C-terminal residue token (lightweight, no parse needed)
+                    cterm_token = _extract_cterm_token(seq)
+                    if cterm_token is not None:
+                        cterm_counts[cterm_token] += 1
+
                     try:
                         parsed_seq, props = pyteomics_proforma.parse(seq)
                         length_counts[len(parsed_seq)] += 1
@@ -1191,6 +1356,22 @@ def summarize_mgf(
                     ["length", "count"],
                     [(ln, length_counts[ln]) for ln in sorted(length_counts)],
                 )
+            if cterm_counts:
+                total_cterm = sum(cterm_counts.values())
+                _write_tsv(
+                    os.path.join(output_root, "cterm_aas.tsv"),
+                    ["amino_acid", "count", "percentage"],
+                    [
+                        (
+                            token,
+                            cterm_counts[token],
+                            f"{100.0 * cterm_counts[token] / total_cterm:.2f}",
+                        )
+                        for token in sorted(
+                            cterm_counts, key=lambda t: -cterm_counts[t]
+                        )
+                    ],
+                )
             if cov_n > 0:
                 cov_tsv_path = os.path.join(output_root, "fragment_coverage.tsv")
                 _write_tsv(
@@ -1256,6 +1437,13 @@ def summarize_mgf(
                     "peptide_lengths.png",
                 )
 
+            cterm_png: str | None = None
+            if cterm_counts:
+                cterm_png = _save_fig(
+                    _make_cterm_bar_fig(cterm_counts),
+                    "cterm_aas.png",
+                )
+
             coverage_png: str | None = None
             if cov_n > 0 and coverage_stats:
                 coverage_png = _save_fig(
@@ -1287,6 +1475,8 @@ def summarize_mgf(
                 coverage_png=coverage_png,
                 coverage_stats=coverage_stats,
                 mod_counts=mod_counts,
+                cterm_counts=cterm_counts,
+                cterm_png=cterm_png,
                 tolerance=tolerance,
                 tolerance_unit=tolerance_unit,
                 max_charge=max_charge,
@@ -1311,6 +1501,7 @@ def summarize_mgf(
 COMMANDS = {
     "summarize": summarize_mgf,
     "charge-distribution": charge_distribution,
+    "count-cterm-aas": cterm_aa_distribution,
     "fragment-coverage": fragment_coverage,
     "peak-counts": peak_counts,
     "peptide-lengths": peptide_lengths,

--- a/tests/test_summarize_mgf.py
+++ b/tests/test_summarize_mgf.py
@@ -633,6 +633,17 @@ def test_count_cterm_aas_no_seq_skipped():
     assert n_skipped == 1
 
 
+def test_count_cterm_aas_invalid_proforma_skipped():
+    """Spectra with invalid ProForma sequences are skipped, not counted."""
+    spectra = [
+        _seq_spectrum("PEPTIDK"),
+        _seq_spectrum("NOT[VALID[PROFORMA"),  # unclosed bracket — invalid ProForma
+    ]
+    counts, n_skipped = count_cterm_aas(spectra)
+    assert counts["K"] == 1
+    assert n_skipped == 1
+
+
 def test_count_cterm_aas_il_counted_separately():
     """I and L at the C-terminus are counted as distinct tokens."""
     spectra = [

--- a/tests/test_summarize_mgf.py
+++ b/tests/test_summarize_mgf.py
@@ -599,13 +599,13 @@ def test_count_cterm_aas_basic():
     """Correct C-terminal tokens are counted at PSM level."""
     spectra = [
         _seq_spectrum("PEPTIDK"),
-        _seq_spectrum("GFLAGGK"),
+        _seq_spectrum("GFLAGGR"),
         _seq_spectrum("PEPTIDR"),
         _seq_spectrum("PEPTIDK"),
     ]
     counts, n_skipped = count_cterm_aas(spectra)
     assert counts["K"] == 2
-    assert counts["R"] == 1
+    assert counts["R"] == 2
     assert n_skipped == 0
 
 

--- a/tests/test_summarize_mgf.py
+++ b/tests/test_summarize_mgf.py
@@ -1,6 +1,7 @@
 import csv
 
 import numpy as np
+import pytest
 
 from casanovoutils.summarize_mgf import (
     _extract_cterm_token,
@@ -723,3 +724,50 @@ def test_cterm_aa_distribution_integration(tmp_path):
 
     assert png_path.exists()
     assert png_path.stat().st_size > 0
+
+
+# ---------------------------------------------------------------------------
+# Graceful exit when all spectra are filtered out
+# ---------------------------------------------------------------------------
+
+SMALL_MGF_NO_SEQ = """\
+BEGIN IONS
+TITLE=spec1
+PEPMASS=500.0
+CHARGE=2+
+100.0 10
+200.0 20
+END IONS
+
+BEGIN IONS
+TITLE=spec2
+PEPMASS=600.0
+CHARGE=3+
+150.0 15
+250.0 25
+END IONS
+"""
+
+
+def test_all_spectra_filtered_exits(tmp_path):
+    """Both peptide_lengths and fragment_coverage exit with a non-zero status
+    when all spectra are filtered out (here: none have SEQ=)."""
+    mgf_path = tmp_path / "no_seq.mgf"
+    mgf_path.write_text(SMALL_MGF_NO_SEQ)
+
+    with pytest.raises(SystemExit) as exc_info:
+        peptide_lengths(
+            str(mgf_path),
+            output_tsv=str(tmp_path / "out.tsv"),
+            output_plot=str(tmp_path / "out.png"),
+        )
+    assert exc_info.value.code != 0
+
+    with pytest.raises(SystemExit) as exc_info:
+        fragment_coverage(
+            str(mgf_path),
+            output_tsv=str(tmp_path / "cov.tsv"),
+            output_full_tsv=str(tmp_path / "cov_full.tsv"),
+            output_plot=str(tmp_path / "cov.png"),
+        )
+    assert exc_info.value.code != 0

--- a/tests/test_summarize_mgf.py
+++ b/tests/test_summarize_mgf.py
@@ -3,9 +3,12 @@ import csv
 import numpy as np
 
 from casanovoutils.summarize_mgf import (
+    _extract_cterm_token,
     charge_distribution,
     count_charge_states,
+    count_cterm_aas,
     count_peaks,
+    cterm_aa_distribution,
     fragment_coverage,
     measure_peptide_lengths,
     peak_counts,
@@ -533,3 +536,179 @@ def test_fragment_coverage_workers_match(tmp_path):
     cov1 = {r["scan"]: r["coverage"] for r in rows1}
     cov2 = {r["scan"]: r["coverage"] for r in rows2}
     assert cov1 == cov2
+
+
+# ---------------------------------------------------------------------------
+# _extract_cterm_token tests (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_cterm_token_bare():
+    """Plain sequence returns the last amino acid."""
+    assert _extract_cterm_token("PEPTIDE") == "E"
+
+
+def test_extract_cterm_token_with_mod():
+    """Last residue with a modification returns the full token."""
+    assert _extract_cterm_token("PEPTK[+229.163]") == "K[+229.163]"
+
+
+def test_extract_cterm_token_named_mod():
+    """Named modification on the last residue is included in the token."""
+    assert _extract_cterm_token("PEPTIC[Carbamidomethyl]") == "C[Carbamidomethyl]"
+
+
+def test_extract_cterm_token_nterm_mod_ignored():
+    """N-terminal modification does not affect C-terminal extraction."""
+    assert _extract_cterm_token("[Acetyl]-PEPTIDER") == "R"
+
+
+def test_extract_cterm_token_cterm_tag_stripped():
+    """ProForma C-terminal sequence tag is stripped; bare residue returned."""
+    assert _extract_cterm_token("PEPTIDE-[Amidated]") == "E"
+
+
+def test_extract_cterm_token_nterm_shift():
+    """Leading mass shift is ignored; correct C-terminal residue returned."""
+    assert (
+        _extract_cterm_token("+229.163AC[Carbamidomethyl]GANHTLVLDSQK[+229.163]")
+        == "K[+229.163]"
+    )
+
+
+def test_extract_cterm_token_empty():
+    """Empty string returns None."""
+    assert _extract_cterm_token("") is None
+
+
+# ---------------------------------------------------------------------------
+# count_cterm_aas tests (pure function)
+# ---------------------------------------------------------------------------
+
+
+def _seq_spectrum(seq):
+    """Build a minimal spectrum dict with only a SEQ= field."""
+    return {
+        "params": {"seq": seq},
+        "m/z array": np.array([]),
+        "intensity array": np.array([]),
+    }
+
+
+def test_count_cterm_aas_basic():
+    """Correct C-terminal tokens are counted at PSM level."""
+    spectra = [
+        _seq_spectrum("PEPTIDK"),
+        _seq_spectrum("GFLAGGK"),
+        _seq_spectrum("PEPTIDR"),
+        _seq_spectrum("PEPTIDK"),
+    ]
+    counts, n_skipped = count_cterm_aas(spectra)
+    assert counts["K"] == 2
+    assert counts["R"] == 1
+    assert n_skipped == 0
+
+
+def test_count_cterm_aas_with_mod():
+    """Residue token including modification is counted separately from bare residue."""
+    spectra = [
+        _seq_spectrum("PEPTIDK[+229.163]"),
+        _seq_spectrum("PEPTIDK"),
+        _seq_spectrum("PEPTIDK[+229.163]"),
+    ]
+    counts, n_skipped = count_cterm_aas(spectra)
+    assert counts["K[+229.163]"] == 2
+    assert counts["K"] == 1
+    assert n_skipped == 0
+
+
+def test_count_cterm_aas_no_seq_skipped():
+    """Spectra without SEQ= are counted as skipped."""
+    spectra = [
+        _seq_spectrum("PEPTIDK"),
+        {"params": {}, "m/z array": np.array([]), "intensity array": np.array([])},
+    ]
+    counts, n_skipped = count_cterm_aas(spectra)
+    assert counts["K"] == 1
+    assert n_skipped == 1
+
+
+def test_count_cterm_aas_il_counted_separately():
+    """I and L at the C-terminus are counted as distinct tokens."""
+    spectra = [
+        _seq_spectrum("PEPTIDI"),
+        _seq_spectrum("PEPTIDL"),
+        _seq_spectrum("PEPTIDL"),
+    ]
+    counts, n_skipped = count_cterm_aas(spectra)
+    assert counts["I"] == 1
+    assert counts["L"] == 2
+    assert n_skipped == 0
+
+
+# ---------------------------------------------------------------------------
+# cterm_aa_distribution integration test
+# ---------------------------------------------------------------------------
+
+SMALL_MGF_CTERM = """\
+BEGIN IONS
+TITLE=spec1
+PEPMASS=500.0
+CHARGE=2+
+SEQ=PEPTIDK
+100.0 10
+END IONS
+
+BEGIN IONS
+TITLE=spec2
+PEPMASS=600.0
+CHARGE=2+
+SEQ=PEPTIDEK[+229.163]
+100.0 10
+END IONS
+
+BEGIN IONS
+TITLE=spec3
+PEPMASS=700.0
+CHARGE=2+
+SEQ=PEPTIDR
+100.0 10
+END IONS
+
+BEGIN IONS
+TITLE=spec4
+PEPMASS=800.0
+CHARGE=2+
+100.0 10
+END IONS
+"""
+
+
+def test_cterm_aa_distribution_integration(tmp_path):
+    """cterm_aa_distribution writes expected TSV (sorted by count) and PNG."""
+    mgf_path = tmp_path / "test.mgf"
+    mgf_path.write_text(SMALL_MGF_CTERM)
+
+    tsv_path = tmp_path / "out.tsv"
+    png_path = tmp_path / "out.png"
+
+    cterm_aa_distribution(str(mgf_path), str(tsv_path), str(png_path))
+
+    with open(tsv_path) as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        rows = list(reader)
+
+    # 3 spectra have SEQ=; 1 is skipped (no SEQ=)
+    assert len(rows) == 3
+    counts = {r["amino_acid"]: int(r["count"]) for r in rows}
+
+    assert counts["K"] == 1
+    assert counts["K[+229.163]"] == 1
+    assert counts["R"] == 1
+
+    # Verify percentage column is present and sums to ~100
+    pcts = [float(r["percentage"]) for r in rows]
+    assert abs(sum(pcts) - 100.0) < 0.1
+
+    assert png_path.exists()
+    assert png_path.stat().st_size > 0


### PR DESCRIPTION
## Summary

- Adds `count-cterm-aas` subcommand to `casanovoutils summarize_mgf` that counts C-terminal residue tokens at PSM level (one tally per spectrum, not per unique peptide)
- The full residue token is used: `K[+229.163]` is counted separately from `K`
- Results TSV has columns `amino_acid`, `count`, `percentage`, sorted by count descending; output is a horizontal bar chart PNG
- The same data is collected during pass 1 of the `summarize` command and rendered as a new "C-terminal Amino Acids" section (table + bar chart) in the HTML report

## New public API

- `_extract_cterm_token(seq)` — strips any trailing ProForma C-terminal sequence tag (`-[mod]`) and returns the last residue token with any attached modification labels
- `count_cterm_aas(spectra)` — pure function over an iterable of pyteomics spectrum dicts; returns `(Counter[str], n_skipped)`
- `cterm_aa_distribution(mgf_file, output_tsv, output_plot)` — CLI function; COMMANDS key `"count-cterm-aas"`

## Test plan

- [ ] Unit tests for `_extract_cterm_token`: bare residue, modified residue, N-term mod, C-term ProForma tag, leading mass shift, empty string
- [ ] Unit tests for `count_cterm_aas`: basic counting, modified token distinct from bare, missing SEQ= skipped, I/L counted separately
- [ ] Integration test for `cterm_aa_distribution`: verifies TSV columns/values and PNG output, checks percentages sum to 100
- [ ] Existing `test_summarize_mgf_integration` continues to pass (HTML, PNG, TSV, log outputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added C-terminal amino acid distribution analysis to MGF summaries.
  - Summary HTML reports now include C-terminal residue counts, percentages, and a bar chart.
  - Added the `count-cterm-aas` command to generate TSV and PNG reports.
  - Supports modified terminal residues and skips spectra without sequence annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->