### PR TITLE
Add filter_spectra command

### DIFF
--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -37,7 +37,14 @@ logger = logging.getLogger(__name__)
 def _load_config(config_path: PathLike) -> dict:
     """Load a Casanovo YAML config and return it as a dict."""
     with open(config_path) as fh:
-        return yaml.safe_load(fh) or {}
+        cfg = yaml.safe_load(fh)
+    if cfg is None:
+        return {}
+    if not isinstance(cfg, dict):
+        raise ValueError(
+            f"Expected a YAML mapping in {config_path!r}, got {type(cfg).__name__}."
+        )
+    return cfg
 
 
 def _seq_to_tokens(seq: str) -> list[str]:
@@ -155,14 +162,14 @@ def filter_spectra(
     # Always attach a file handler for log_out, even if root handlers exist
     # from a prior configure_logging call.
     configure_logging(log_out)
-    file_handler = logging.FileHandler(log_out)
-    file_handler.setFormatter(
-        logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
-    )
     if not any(
         isinstance(h, logging.FileHandler) and h.baseFilename == str(log_out.resolve())
         for h in logging.root.handlers
     ):
+        file_handler = logging.FileHandler(log_out)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+        )
         logging.root.addHandler(file_handler)
 
     cfg = _load_config(config)

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _load_config(config_path: PathLike) -> dict:
+def load_config(config_path: PathLike) -> dict:
     """Load a Casanovo YAML config and return it as a dict."""
     with open(config_path) as fh:
         cfg = yaml.safe_load(fh)
@@ -47,7 +47,7 @@ def _load_config(config_path: PathLike) -> dict:
     return cfg
 
 
-def _make_tokenizer(cfg: dict) -> PeptideTokenizer:
+def make_tokenizer(cfg: dict) -> PeptideTokenizer:
     """Build a PeptideTokenizer from the residues in a Casanovo config."""
     return PeptideTokenizer(
         residues=cfg.get("residues", {}),
@@ -57,7 +57,7 @@ def _make_tokenizer(cfg: dict) -> PeptideTokenizer:
     )
 
 
-def _parse_charge(charge_raw) -> Optional[int]:
+def parse_charge(charge_raw) -> Optional[int]:
     """
     Return the charge as a positive int, or ``None`` if it is missing,
     ambiguous, zero, or cannot be converted.
@@ -125,10 +125,10 @@ def filter_spectra(
 
     configure_logging(log_out)
 
-    cfg = _load_config(config)
+    cfg = load_config(config)
     min_peaks: int = cfg.get("min_peaks", 20)
     max_charge: int = cfg.get("max_charge", 10)
-    tokenizer = _make_tokenizer(cfg)
+    tokenizer = make_tokenizer(cfg)
 
     logger.info("Input MGF  : %s", mgf_file)
     logger.info("Config     : %s", config)
@@ -167,7 +167,7 @@ def filter_spectra(
                 continue
 
             # --- 3. Invalid charge ------------------------------------------
-            charge = _parse_charge(spectrum["params"].get("charge"))
+            charge = parse_charge(spectrum["params"].get("charge"))
             if charge is None or charge <= 0 or charge > max_charge:
                 n_bad_charge += 1
                 continue

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -1,0 +1,225 @@
+"""
+Filter an annotated MGF file using the same criteria applied by Casanovo.
+
+Removes spectra that would be silently skipped or crash Casanovo during
+training:
+
+* Missing or empty ``SEQ`` field.
+* Sequence contains tokens not present in the Casanovo residue vocabulary.
+* Precursor charge is missing, ambiguous, or exceeds ``max_charge``.
+* Spectrum has fewer than ``min_peaks`` peaks (before any Casanovo
+  peak-intensity filtering).
+
+Outputs a filtered MGF and a log file with per-criterion counts.
+"""
+
+import logging
+import pathlib
+from os import PathLike
+from typing import Optional
+
+import pyteomics.mgf
+import tqdm
+import yaml
+from pyteomics import proforma as pf
+
+from . import configure_logging
+from .types import Commands, PyteomicsSpectrum
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_config(config_path: PathLike) -> dict:
+    """Load a Casanovo YAML config and return it as a dict."""
+    with open(config_path) as fh:
+        return yaml.safe_load(fh)
+
+
+def _seq_to_tokens(seq: str) -> list[str]:
+    """
+    Split a ProForma sequence into tokens using the same format as
+    depthcharge's ``PeptideTokenizer.split()``.
+
+    Named modifications produce tokens like ``C[Carbamidomethyl]`` and
+    ``[Acetyl]-``; mass modifications produce tokens like
+    ``K[+229.163000]`` and ``[+271.174000]-``.
+
+    Returns a list of token strings, or raises ``ValueError`` if the
+    ProForma string cannot be parsed.
+    """
+    residues, meta = pf.parse(seq)
+
+    def _mod_str(mods: list) -> str:
+        """Format a list of pyteomics modification objects as ``[...]``."""
+        if len(mods) == 1:
+            try:
+                return f"[{mods[0].name}]"
+            except (AttributeError, ValueError):
+                return f"[{mods[0].mass:+0.6f}]"
+        # Multiple mods: sum masses.
+        total = sum(m.mass for m in mods)
+        return f"[{total:+0.6f}]"
+
+    tokens: list[str] = []
+
+    # N-terminal modification.
+    n_term = meta.get("n_term")
+    if n_term:
+        tokens.append(f"{_mod_str(n_term)}-")
+
+    # Residues.
+    for aa, mods in residues:
+        if mods:
+            tokens.append(f"{aa}{_mod_str(mods)}")
+        else:
+            tokens.append(aa)
+
+    # C-terminal modification.
+    c_term = meta.get("c_term")
+    if c_term:
+        tokens.append(f"-{_mod_str(c_term)}")
+
+    return tokens
+
+
+def _parse_charge(charge_raw) -> Optional[int]:
+    """
+    Return the charge as a positive int, or ``None`` if it is missing,
+    ambiguous, zero, or cannot be converted.
+    """
+    try:
+        if isinstance(charge_raw, list):
+            if len(charge_raw) != 1:
+                return None
+            return int(charge_raw[0])
+        return int(charge_raw)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Core command
+# ---------------------------------------------------------------------------
+
+def filter_spectra(
+    mgf_file: PathLike,
+    config: PathLike,
+    output_root: str = "filtered",
+    output_dir: PathLike = ".",
+) -> None:
+    """
+    Filter an annotated MGF file using Casanovo's spectrum acceptance criteria.
+
+    Reads *mgf_file*, removes spectra that Casanovo would reject, and writes
+    the survivors to ``<output_dir>/<output_root>.mgf``.  A summary of how
+    many spectra were removed by each criterion is written to
+    ``<output_dir>/<output_root>.log``.
+
+    Parameters
+    ----------
+    mgf_file : PathLike
+        Input annotated MGF file.
+    config : PathLike
+        Casanovo YAML configuration file.  The fields ``residues``,
+        ``replace_isoleucine_with_leucine``, ``min_peaks``, and
+        ``max_charge`` are read from this file.
+    output_root : str, optional
+        Stem used for output file names (default ``"filtered"``).
+    output_dir : PathLike, optional
+        Directory in which to write output files (default: current directory).
+    """
+    output_dir = pathlib.Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    mgf_out = output_dir / f"{output_root}.mgf"
+    log_out = output_dir / f"{output_root}.log"
+
+    configure_logging(log_out)
+
+    cfg = _load_config(config)
+    min_peaks: int = cfg.get("min_peaks", 20)
+    max_charge: int = cfg.get("max_charge", 10)
+    replace_il: bool = cfg.get("replace_isoleucine_with_leucine", False)
+
+    # Build the valid-token set from the config residues, mirroring
+    # PeptideTokenizer: always include the 20 standard amino acids, then
+    # add (or override with) whatever is in the config.
+    _STANDARD_AAS = set("ACDEFGHIKLMNPQRSTVWY")
+    residues: dict = cfg.get("residues", {})
+    valid_tokens: set[str] = _STANDARD_AAS | set(residues.keys())
+    if replace_il and "I" in valid_tokens:
+        valid_tokens.discard("I")
+
+    logger.info("Input MGF  : %s", mgf_file)
+    logger.info("Config     : %s", config)
+    logger.info("min_peaks  : %d", min_peaks)
+    logger.info("max_charge : %d", max_charge)
+    logger.info("Output MGF : %s", mgf_out)
+
+    n_total = 0
+    n_no_seq = 0
+    n_bad_seq = 0
+    n_bad_charge = 0
+    n_few_peaks = 0
+
+    passing: list[PyteomicsSpectrum] = []
+
+    for spectrum in tqdm.tqdm(
+        pyteomics.mgf.read(str(mgf_file), use_index=False),
+        desc=f"Filtering {mgf_file}",
+        unit="psm",
+    ):
+        n_total += 1
+
+        # --- 1. Missing or empty SEQ ----------------------------------------
+        seq = spectrum["params"].get("seq", "")
+        if not seq:
+            n_no_seq += 1
+            continue
+
+        # --- 2. Unknown tokens in sequence ----------------------------------
+        try:
+            tokens = _seq_to_tokens(seq)
+        except Exception:
+            n_bad_seq += 1
+            continue
+        if any(t not in valid_tokens for t in tokens):
+            n_bad_seq += 1
+            continue
+
+        # --- 3. Invalid charge ----------------------------------------------
+        charge = _parse_charge(spectrum["params"].get("charge"))
+        if charge is None or charge <= 0 or charge > max_charge:
+            n_bad_charge += 1
+            continue
+
+        # --- 4. Too few peaks -----------------------------------------------
+        if len(spectrum.get("m/z array", [])) < min_peaks:
+            n_few_peaks += 1
+            continue
+
+        passing.append(spectrum)
+
+    n_pass = len(passing)
+    n_filtered = n_total - n_pass
+
+    logger.info("---")
+    logger.info("Total spectra read        : %d", n_total)
+    logger.info("Filtered: missing SEQ     : %d", n_no_seq)
+    logger.info("Filtered: invalid tokens  : %d", n_bad_seq)
+    logger.info("Filtered: invalid charge  : %d", n_bad_charge)
+    logger.info("Filtered: too few peaks   : %d", n_few_peaks)
+    logger.info("Filtered: total           : %d", n_filtered)
+    logger.info("Passing spectra written   : %d", n_pass)
+
+    pyteomics.mgf.write(
+        tqdm.tqdm(passing, desc=f"Writing {mgf_out}", unit="psm"),
+        output=str(mgf_out),
+    )
+
+
+COMMANDS = filter_spectra

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -123,18 +123,7 @@ def filter_spectra(
                 f"Use --overwrite to overwrite."
             )
 
-    # Always attach a file handler for log_out, even if root handlers exist
-    # from a prior configure_logging call.
     configure_logging(log_out)
-    if not any(
-        isinstance(h, logging.FileHandler) and h.baseFilename == str(log_out.resolve())
-        for h in logging.root.handlers
-    ):
-        file_handler = logging.FileHandler(log_out)
-        file_handler.setFormatter(
-            logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
-        )
-        logging.root.addHandler(file_handler)
 
     cfg = _load_config(config)
     min_peaks: int = cfg.get("min_peaks", 20)

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -16,7 +16,7 @@ Outputs a filtered MGF and a log file with per-criterion counts.
 import logging
 import pathlib
 from os import PathLike
-from typing import Optional
+from typing import Generator, Optional
 
 import pyteomics.mgf
 import tqdm
@@ -24,7 +24,7 @@ import yaml
 from pyteomics import proforma as pf
 
 from . import configure_logging
-from .types import Commands, PyteomicsSpectrum
+from .types import PyteomicsSpectrum
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +33,11 @@ logger = logging.getLogger(__name__)
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _load_config(config_path: PathLike) -> dict:
     """Load a Casanovo YAML config and return it as a dict."""
     with open(config_path) as fh:
-        return yaml.safe_load(fh)
+        return yaml.safe_load(fh) or {}
 
 
 def _seq_to_tokens(seq: str) -> list[str]:
@@ -48,8 +49,7 @@ def _seq_to_tokens(seq: str) -> list[str]:
     ``[Acetyl]-``; mass modifications produce tokens like
     ``K[+229.163000]`` and ``[+271.174000]-``.
 
-    Returns a list of token strings, or raises ``ValueError`` if the
-    ProForma string cannot be parsed.
+    Raises an exception if the ProForma string cannot be parsed.
     """
     residues, meta = pf.parse(seq)
 
@@ -105,11 +105,13 @@ def _parse_charge(charge_raw) -> Optional[int]:
 # Core command
 # ---------------------------------------------------------------------------
 
+
 def filter_spectra(
     mgf_file: PathLike,
     config: PathLike,
     output_root: str = "filtered",
     output_dir: PathLike = ".",
+    overwrite: bool = False,
 ) -> None:
     """
     Filter an annotated MGF file using Casanovo's spectrum acceptance criteria.
@@ -131,6 +133,9 @@ def filter_spectra(
         Stem used for output file names (default ``"filtered"``).
     output_dir : PathLike, optional
         Directory in which to write output files (default: current directory).
+    overwrite : bool, optional
+        If False (default), raise ``FileExistsError`` if any output file
+        already exists.
     """
     output_dir = pathlib.Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -138,7 +143,27 @@ def filter_spectra(
     mgf_out = output_dir / f"{output_root}.mgf"
     log_out = output_dir / f"{output_root}.log"
 
+    if not overwrite:
+        existing = [p for p in (mgf_out, log_out) if p.exists()]
+        if existing:
+            paths = ", ".join(str(p) for p in existing)
+            raise FileExistsError(
+                f"Output file(s) already exist: {paths}. "
+                f"Use --overwrite to overwrite."
+            )
+
+    # Always attach a file handler for log_out, even if root handlers exist
+    # from a prior configure_logging call.
     configure_logging(log_out)
+    file_handler = logging.FileHandler(log_out)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+    )
+    if not any(
+        isinstance(h, logging.FileHandler) and h.baseFilename == str(log_out.resolve())
+        for h in logging.root.handlers
+    ):
+        logging.root.addHandler(file_handler)
 
     cfg = _load_config(config)
     min_peaks: int = cfg.get("min_peaks", 20)
@@ -151,7 +176,9 @@ def filter_spectra(
     _STANDARD_AAS = set("ACDEFGHIKLMNPQRSTVWY")
     residues: dict = cfg.get("residues", {})
     valid_tokens: set[str] = _STANDARD_AAS | set(residues.keys())
-    if replace_il and "I" in valid_tokens:
+    # When I→L replacement is active, I is not a valid token; sequences
+    # containing I are canonicalized to L before vocabulary lookup.
+    if replace_il:
         valid_tokens.discard("I")
 
     logger.info("Input MGF  : %s", mgf_file)
@@ -165,48 +192,58 @@ def filter_spectra(
     n_bad_seq = 0
     n_bad_charge = 0
     n_few_peaks = 0
+    n_pass = 0
 
-    passing: list[PyteomicsSpectrum] = []
+    def _filtered_spectra() -> Generator[PyteomicsSpectrum, None, None]:
+        nonlocal n_total, n_no_seq, n_bad_seq, n_bad_charge, n_few_peaks, n_pass
 
-    for spectrum in tqdm.tqdm(
-        pyteomics.mgf.read(str(mgf_file), use_index=False),
-        desc=f"Filtering {mgf_file}",
-        unit="psm",
-    ):
-        n_total += 1
+        for spectrum in tqdm.tqdm(
+            pyteomics.mgf.read(str(mgf_file), use_index=False),
+            desc=f"Filtering {mgf_file}",
+            unit="psm",
+        ):
+            n_total += 1
 
-        # --- 1. Missing or empty SEQ ----------------------------------------
-        seq = spectrum["params"].get("seq", "")
-        if not seq:
-            n_no_seq += 1
-            continue
+            # --- 1. Missing or empty SEQ ------------------------------------
+            seq = spectrum["params"].get("seq", "")
+            if not seq:
+                n_no_seq += 1
+                continue
 
-        # --- 2. Unknown tokens in sequence ----------------------------------
-        try:
-            tokens = _seq_to_tokens(seq)
-        except Exception:
-            n_bad_seq += 1
-            continue
-        if any(t not in valid_tokens for t in tokens):
-            n_bad_seq += 1
-            continue
+            # --- 2. Unknown tokens in sequence ------------------------------
+            try:
+                tokens = _seq_to_tokens(seq)
+            except Exception:  # noqa: BLE001 — pyteomics raises heterogeneous types
+                n_bad_seq += 1
+                continue
+            # When replace_isoleucine_with_leucine is set, canonicalize I→L
+            # in tokens before vocabulary lookup, matching Casanovo's behavior.
+            if replace_il:
+                tokens = [t.replace("I", "L") for t in tokens]
+            if any(t not in valid_tokens for t in tokens):
+                n_bad_seq += 1
+                continue
 
-        # --- 3. Invalid charge ----------------------------------------------
-        charge = _parse_charge(spectrum["params"].get("charge"))
-        if charge is None or charge <= 0 or charge > max_charge:
-            n_bad_charge += 1
-            continue
+            # --- 3. Invalid charge ------------------------------------------
+            charge = _parse_charge(spectrum["params"].get("charge"))
+            if charge is None or charge <= 0 or charge > max_charge:
+                n_bad_charge += 1
+                continue
 
-        # --- 4. Too few peaks -----------------------------------------------
-        if len(spectrum.get("m/z array", [])) < min_peaks:
-            n_few_peaks += 1
-            continue
+            # --- 4. Too few peaks -------------------------------------------
+            if len(spectrum.get("m/z array", [])) < min_peaks:
+                n_few_peaks += 1
+                continue
 
-        passing.append(spectrum)
+            n_pass += 1
+            yield spectrum
 
-    n_pass = len(passing)
+    pyteomics.mgf.write(
+        tqdm.tqdm(_filtered_spectra(), desc=f"Writing {mgf_out}", unit="psm"),
+        output=str(mgf_out),
+    )
+
     n_filtered = n_total - n_pass
-
     logger.info("---")
     logger.info("Total spectra read        : %d", n_total)
     logger.info("Filtered: missing SEQ     : %d", n_no_seq)
@@ -215,11 +252,6 @@ def filter_spectra(
     logger.info("Filtered: too few peaks   : %d", n_few_peaks)
     logger.info("Filtered: total           : %d", n_filtered)
     logger.info("Passing spectra written   : %d", n_pass)
-
-    pyteomics.mgf.write(
-        tqdm.tqdm(passing, desc=f"Writing {mgf_out}", unit="psm"),
-        output=str(mgf_out),
-    )
 
 
 COMMANDS = filter_spectra

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -21,7 +21,7 @@ from typing import Generator, Optional
 import pyteomics.mgf
 import tqdm
 import yaml
-from pyteomics import proforma as pf
+from depthcharge.tokenizers import PeptideTokenizer
 
 from . import configure_logging
 from .types import PyteomicsSpectrum
@@ -47,50 +47,14 @@ def _load_config(config_path: PathLike) -> dict:
     return cfg
 
 
-def _seq_to_tokens(seq: str) -> list[str]:
-    """
-    Split a ProForma sequence into tokens using the same format as
-    depthcharge's ``PeptideTokenizer.split()``.
-
-    Named modifications produce tokens like ``C[Carbamidomethyl]`` and
-    ``[Acetyl]-``; mass modifications produce tokens like
-    ``K[+229.163000]`` and ``[+271.174000]-``.
-
-    Raises an exception if the ProForma string cannot be parsed.
-    """
-    residues, meta = pf.parse(seq)
-
-    def _mod_str(mods: list) -> str:
-        """Format a list of pyteomics modification objects as ``[...]``."""
-        if len(mods) == 1:
-            try:
-                return f"[{mods[0].name}]"
-            except (AttributeError, ValueError):
-                return f"[{mods[0].mass:+0.6f}]"
-        # Multiple mods: sum masses.
-        total = sum(m.mass for m in mods)
-        return f"[{total:+0.6f}]"
-
-    tokens: list[str] = []
-
-    # N-terminal modification.
-    n_term = meta.get("n_term")
-    if n_term:
-        tokens.append(f"{_mod_str(n_term)}-")
-
-    # Residues.
-    for aa, mods in residues:
-        if mods:
-            tokens.append(f"{aa}{_mod_str(mods)}")
-        else:
-            tokens.append(aa)
-
-    # C-terminal modification.
-    c_term = meta.get("c_term")
-    if c_term:
-        tokens.append(f"-{_mod_str(c_term)}")
-
-    return tokens
+def _make_tokenizer(cfg: dict) -> PeptideTokenizer:
+    """Build a PeptideTokenizer from the residues in a Casanovo config."""
+    return PeptideTokenizer(
+        residues=cfg.get("residues", {}),
+        replace_isoleucine_with_leucine=cfg.get(
+            "replace_isoleucine_with_leucine", False
+        ),
+    )
 
 
 def _parse_charge(charge_raw) -> Optional[int]:
@@ -175,18 +139,7 @@ def filter_spectra(
     cfg = _load_config(config)
     min_peaks: int = cfg.get("min_peaks", 20)
     max_charge: int = cfg.get("max_charge", 10)
-    replace_il: bool = cfg.get("replace_isoleucine_with_leucine", False)
-
-    # Build the valid-token set from the config residues, mirroring
-    # PeptideTokenizer: always include the 20 standard amino acids, then
-    # add (or override with) whatever is in the config.
-    _STANDARD_AAS = set("ACDEFGHIKLMNPQRSTVWY")
-    residues: dict = cfg.get("residues", {})
-    valid_tokens: set[str] = _STANDARD_AAS | set(residues.keys())
-    # When I→L replacement is active, I is not a valid token; sequences
-    # containing I are canonicalized to L before vocabulary lookup.
-    if replace_il:
-        valid_tokens.discard("I")
+    tokenizer = _make_tokenizer(cfg)
 
     logger.info("Input MGF  : %s", mgf_file)
     logger.info("Config     : %s", config)
@@ -219,15 +172,8 @@ def filter_spectra(
 
             # --- 2. Unknown tokens in sequence ------------------------------
             try:
-                tokens = _seq_to_tokens(seq)
-            except Exception:  # noqa: BLE001 — pyteomics raises heterogeneous types
-                n_bad_seq += 1
-                continue
-            # When replace_isoleucine_with_leucine is set, canonicalize I→L
-            # in tokens before vocabulary lookup, matching Casanovo's behavior.
-            if replace_il:
-                tokens = [t.replace("I", "L") for t in tokens]
-            if any(t not in valid_tokens for t in tokens):
+                tokenizer.tokenize(seq)
+            except ValueError:
                 n_bad_seq += 1
                 continue
 

--- a/tests/test_filter_spectra.py
+++ b/tests/test_filter_spectra.py
@@ -1,0 +1,286 @@
+"""Tests for the filter_spectra command."""
+
+import numpy as np
+import pyteomics.mgf
+import pytest
+import yaml
+
+from casanovoutils.filter_spectra import filter_spectra
+
+
+def _write_config(path, residues=None, min_peaks=2, max_charge=5):
+    """Write a minimal Casanovo YAML config."""
+    cfg = {
+        "min_peaks": min_peaks,
+        "max_charge": max_charge,
+    }
+    if residues is not None:
+        cfg["residues"] = residues
+    with open(path, "w") as fh:
+        yaml.dump(cfg, fh)
+    return str(path)
+
+
+def _write_mgf(path, spectra):
+    """Write spectra as an MGF file.
+
+    Parameters
+    ----------
+    spectra : list[dict]
+        Each dict may contain keys: seq, charge, mz, intensity.
+    """
+    records = []
+    for s in spectra:
+        params = {"pepmass": (500.0,)}
+        if "seq" in s:
+            params["seq"] = s["seq"]
+        if "charge" in s:
+            params["charge"] = [s["charge"]]
+        records.append(
+            {
+                "params": params,
+                "m/z array": np.array(s.get("mz", [100.0, 200.0, 300.0])),
+                "intensity array": np.array(s.get("intensity", [1.0, 1.0, 1.0])),
+            }
+        )
+    pyteomics.mgf.write(records, output=str(path))
+    return str(path)
+
+
+def _read_seqs(path):
+    spectra = list(pyteomics.mgf.read(str(path), use_index=False))
+    return [s["params"].get("seq") for s in spectra]
+
+
+# Three peaks satisfies min_peaks=2; we use this as the "good" default.
+_GOOD = {
+    "seq": "PEPTIDE",
+    "charge": 2,
+    "mz": [100.0, 200.0, 300.0],
+    "intensity": [1.0, 1.0, 1.0],
+}
+
+
+class TestFilterSpectraMissingSeq:
+    def test_missing_seq_filtered(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [{"charge": 2, "mz": [100.0, 200.0, 300.0], "intensity": [1.0, 1.0, 1.0]}],
+        )
+        _write_config(cfg)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == []
+
+    def test_empty_seq_filtered(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [
+                {
+                    "seq": "",
+                    "charge": 2,
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                }
+            ],
+        )
+        _write_config(cfg)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == []
+
+
+class TestFilterSpectraInvalidTokens:
+    def test_unknown_token_filtered(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        # B is not a standard amino acid and not in the config residues
+        _write_mgf(
+            mgf_in,
+            [
+                {
+                    "seq": "PEPBIDE",
+                    "charge": 2,
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                }
+            ],
+        )
+        _write_config(cfg)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == []
+
+    def test_known_modification_passes(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [
+                {
+                    "seq": "PEPTM[Oxidation]IDE",
+                    "charge": 2,
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                }
+            ],
+        )
+        _write_config(cfg, residues={"M[Oxidation]": 147.035})
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == ["PEPTM[Oxidation]IDE"]
+
+
+class TestFilterSpectraInvalidCharge:
+    def test_missing_charge_filtered(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [
+                {
+                    "seq": "PEPTIDE",
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                }
+            ],
+        )
+        _write_config(cfg)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == []
+
+    def test_charge_exceeds_max_filtered(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [
+                {
+                    "seq": "PEPTIDE",
+                    "charge": 6,
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                }
+            ],
+        )
+        _write_config(cfg, max_charge=5)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == []
+
+    def test_charge_at_max_passes(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [
+                {
+                    "seq": "PEPTIDE",
+                    "charge": 5,
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                }
+            ],
+        )
+        _write_config(cfg, max_charge=5)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == ["PEPTIDE"]
+
+
+class TestFilterSpectraTooFewPeaks:
+    def test_too_few_peaks_filtered(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in, [{"seq": "PEPTIDE", "charge": 2, "mz": [100.0], "intensity": [1.0]}]
+        )
+        _write_config(cfg, min_peaks=2)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == []
+
+    def test_exactly_min_peaks_passes(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [
+                {
+                    "seq": "PEPTIDE",
+                    "charge": 2,
+                    "mz": [100.0, 200.0],
+                    "intensity": [1.0, 1.0],
+                }
+            ],
+        )
+        _write_config(cfg, min_peaks=2)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == ["PEPTIDE"]
+
+
+class TestFilterSpectraPassThrough:
+    def test_valid_spectrum_passes(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(mgf_in, [_GOOD])
+        _write_config(cfg)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == ["PEPTIDE"]
+
+    def test_mixed_spectra_only_valid_pass(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(
+            mgf_in,
+            [
+                _GOOD,
+                {
+                    "seq": "PEPBIDE",
+                    "charge": 2,
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                },
+                {
+                    "seq": "VALIDPEP",
+                    "charge": 3,
+                    "mz": [100.0, 200.0, 300.0],
+                    "intensity": [1.0, 1.0, 1.0],
+                },
+            ],
+        )
+        _write_config(cfg)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        assert _read_seqs(tmp_path / "out.mgf") == ["PEPTIDE", "VALIDPEP"]
+
+    def test_overwrite_false_raises_on_existing(self, tmp_path):
+        mgf_in = tmp_path / "in.mgf"
+        cfg = tmp_path / "config.yaml"
+        _write_mgf(mgf_in, [_GOOD])
+        _write_config(cfg)
+        filter_spectra(
+            mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=True
+        )
+        with pytest.raises(FileExistsError):
+            filter_spectra(
+                mgf_in, cfg, output_root="out", output_dir=tmp_path, overwrite=False
+            )


### PR DESCRIPTION
## Summary

- Adds a new `casanovoutils filter_spectra` CLI command that reads an annotated MGF and a Casanovo YAML config, and writes a filtered MGF removing spectra that Casanovo would reject during training
- Filters on four criteria, applied in order: missing/empty SEQ field; sequence tokens not in the Casanovo residue vocabulary (e.g. unknown modifications like `K[+229.163]`); precursor charge missing, ambiguous, or exceeding `max_charge`; fewer than `min_peaks` peaks
- Outputs `<output_dir>/<output_root>.mgf` (filtered spectra) and `<output_dir>/<output_root>.log` (per-criterion counts)
- Token splitting is done via `pyteomics.proforma` using the same format as depthcharge's `PeptideTokenizer.split()`, avoiding a direct depthcharge import (which transitively requires polars)

## Test plan

- [ ] Run `casanovoutils filter_spectra <mgf> <config.yaml> --output_root=filtered --output_dir=<dir>` on a known MGF and verify the log counts sum correctly to total input
- [ ] Confirm spectra with `K[+229.163]`-style modifications are filtered under "invalid tokens"
- [ ] Confirm spectra with charge > `max_charge` are filtered under "invalid charge"
- [ ] Confirm spectra with fewer than `min_peaks` peaks are filtered under "too few peaks"
- [ ] Confirm all tokens in the output MGF are present in the config residue vocabulary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a filtering command for annotated MGF spectra.
  * Supports configuration-based filtering by sequence validity, precursor charge, and minimum peak count.
  * Produces a filtered MGF output and reports counts for spectra excluded by each criterion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->