### PR TITLE
Add casanovo_config parameter to create_datasets for pre-split filtering

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- `--casanovo_config` and `--tmp_dir` were added as flags for `casanovoutils
+  datasets`. If used, `--casanovo_config`` filters spectra based on `min_peaks`,
+  `max_charge` and `residues` in the config. `--tmp_dir` is the directory to
+  store temporary converted and filtered MGFs.
 - `casanovoutils mgf pipeline`: chain shuffle, downsample, and purge-redundant
   in a single command with each stage independently optional.
 - `casanovoutils mgf purge-redundant`: remove near-duplicate peaks within each

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - `--casanovo_config` and `--tmp_dir` were added as flags for `casanovoutils
   datasets`. If used, `--casanovo_config`` filters spectra based on `min_peaks`,
-  `max_charge` and `residues` in the config. `--tmp_dir` is the directory to
-  store temporary converted and filtered MGFs.
+  `max_charge`, `residues`, and `replace_isoleucine_with_leucine` in the config.
+  `--tmp_dir` is the directory to store temporary converted and filtered MGFs.
 - `casanovoutils mgf pipeline`: chain shuffle, downsample, and purge-redundant
   in a single command with each stage independently optional.
 - `casanovoutils mgf purge-redundant`: remove near-duplicate peaks within each

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -458,6 +458,9 @@ The following output files are written:
 | `--existing_splits` | paths | `None` | Tuple of existing (train, val, test) MGF paths to extend |
 | `--combine_with_existing` | bool | `False` | Include existing spectra in output alongside new ones |
 | `--mskb_format` | bool | `False` | Convert input sequences from MassIVE-KB PTM notation to ProForma before splitting |
+| `--casanovo_config` | PathLike | `None | Filters spectra based on thresholds in the config (``residues``, ``min_peaks``, ``max_charge``, and
+        ``replace_isoleucine_with_leucine``) |
+| `--tmp_dir` | PathLike | `None` | Directory to store temporary files | 
 
 **Examples:**
 

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -13,6 +13,7 @@ import pyteomics.mgf
 import tqdm
 
 from . import configure_logging
+from .filter_spectra import _load_config, _parse_charge, _seq_to_tokens
 from .mskb2proforma import convert as _mskb2proforma_convert
 from .types import Commands
 
@@ -622,6 +623,97 @@ def _write_splits(
     return split_spectra_counts, split_pep_sets, mod_to_bare_by_split
 
 
+def _filter_mgf_files(
+    mgf_files: tuple[PathLike, ...],
+    casanovo_config: PathLike,
+    tmpdir: pathlib.Path,
+) -> tuple[PathLike, ...]:
+    """Filter MGF files using a Casanovo config, writing results to *tmpdir*.
+
+    For each input file, spectra that fail any of the following checks are
+    removed:
+
+    * Missing or empty ``SEQ`` field.
+    * Sequence contains tokens absent from the Casanovo residue vocabulary.
+    * Precursor charge is missing, ambiguous, zero, or exceeds ``max_charge``.
+    * Fewer than ``min_peaks`` peaks.
+
+    Per-criterion counts are written to the log. Returns a tuple of paths to
+    the filtered MGF files in the same order as *mgf_files*.
+    """
+    cfg = _load_config(casanovo_config)
+    min_peaks: int = cfg.get("min_peaks", 20)
+    max_charge: int = cfg.get("max_charge", 10)
+    replace_il: bool = cfg.get("replace_isoleucine_with_leucine", False)
+
+    _STANDARD_AAS = set("ACDEFGHIKLMNPQRSTVWY")
+    residues: dict = cfg.get("residues", {})
+    valid_tokens: set[str] = _STANDARD_AAS | set(residues.keys())
+    if replace_il:
+        valid_tokens.discard("I")
+
+    logging.info(
+        f"Filtering with Casanovo config: {casanovo_config} "
+        f"(min_peaks={min_peaks}, max_charge={max_charge})"
+    )
+
+    n_total = n_no_seq = n_bad_seq = n_bad_charge = n_few_peaks = 0
+
+    filtered: list[PathLike] = []
+    for i, src in enumerate(mgf_files):
+        src = pathlib.Path(src)
+        dst = tmpdir / f"filtered_{i}_{src.name}"
+        spectra_out = []
+
+        for spectrum in tqdm.tqdm(
+            pyteomics.mgf.read(str(src), use_index=False),
+            desc=f"Filtering {src.name}",
+            unit="psm",
+        ):
+            n_total += 1
+
+            seq = spectrum["params"].get("seq", "")
+            if not seq:
+                n_no_seq += 1
+                continue
+
+            try:
+                tokens = _seq_to_tokens(seq)
+            except Exception:  # noqa: BLE001
+                n_bad_seq += 1
+                continue
+            if replace_il:
+                tokens = [t.replace("I", "L") for t in tokens]
+            if any(t not in valid_tokens for t in tokens):
+                n_bad_seq += 1
+                continue
+
+            charge = _parse_charge(spectrum["params"].get("charge"))
+            if charge is None or charge <= 0 or charge > max_charge:
+                n_bad_charge += 1
+                continue
+
+            if len(spectrum.get("m/z array", [])) < min_peaks:
+                n_few_peaks += 1
+                continue
+
+            spectra_out.append(spectrum)
+
+        pyteomics.mgf.write(spectra_out, output=str(dst))
+        filtered.append(dst)
+
+    n_pass = n_total - n_no_seq - n_bad_seq - n_bad_charge - n_few_peaks
+    logging.info(f"Filtering complete — total spectra read : {n_total}")
+    logging.info(f"  Filtered: missing SEQ     : {n_no_seq}")
+    logging.info(f"  Filtered: invalid tokens  : {n_bad_seq}")
+    logging.info(f"  Filtered: invalid charge  : {n_bad_charge}")
+    logging.info(f"  Filtered: too few peaks   : {n_few_peaks}")
+    logging.info(f"  Filtered: total           : {n_total - n_pass}")
+    logging.info(f"  Passing spectra           : {n_pass}")
+
+    return tuple(filtered)
+
+
 def create_datasets(
     *mgf_files: PathLike,
     output_root: str,
@@ -631,6 +723,7 @@ def create_datasets(
     existing_splits: Optional[tuple[PathLike, PathLike, PathLike]] = None,
     combine_with_existing: bool = False,
     mskb_format: bool = False,
+    casanovo_config: Optional[PathLike] = None,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -698,6 +791,15 @@ def create_datasets(
         files will contain the converted ProForma sequences, not the original
         MassIVE-KB strings. Conversion raises a ``ValueError`` if any
         sequence cannot be converted.
+    casanovo_config : PathLike, optional
+        Path to a Casanovo YAML configuration file. If provided, spectra are
+        filtered before splitting using the vocabulary and thresholds in the
+        config (``residues``, ``min_peaks``, ``max_charge``, and
+        ``replace_isoleucine_with_leucine``). Spectra with a missing or empty
+        SEQ field, tokens outside the vocabulary, an invalid or out-of-range
+        charge, or fewer than ``min_peaks`` peaks are removed. Filtering is
+        applied after any MassIVE-KB conversion. Per-criterion counts are
+        written to the log file.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -739,8 +841,8 @@ def create_datasets(
         random.seed(random_seed)
 
         with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = pathlib.Path(tmpdir)
             if mskb_format:
-                tmp = pathlib.Path(tmpdir)
                 converted = []
                 for i, src in enumerate(mgf_files):
                     src = pathlib.Path(src)
@@ -751,6 +853,9 @@ def create_datasets(
                     _mskb2proforma_convert(src, dst)
                     converted.append(dst)
                 mgf_files = tuple(converted)
+
+            if casanovo_config is not None:
+                mgf_files = _filter_mgf_files(mgf_files, casanovo_config, tmp)
 
             pep_counts, sampling_counts, total_spectra = _collect_peptide_counts(
                 mgf_files

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -13,7 +13,7 @@ import pyteomics.mgf
 import tqdm
 
 from . import configure_logging
-from .filter_spectra import _load_config, _make_tokenizer, _parse_charge
+from .filter_spectra import load_config, make_tokenizer, parse_charge
 from .mskb2proforma import convert as _mskb2proforma_convert
 from .types import Commands
 
@@ -641,10 +641,10 @@ def _filter_mgf_files(
     Per-criterion counts are written to the log. Returns a tuple of paths to
     the filtered MGF files in the same order as *mgf_files*.
     """
-    cfg = _load_config(casanovo_config)
+    cfg = load_config(casanovo_config)
     min_peaks: int = cfg.get("min_peaks", 20)
     max_charge: int = cfg.get("max_charge", 10)
-    tokenizer = _make_tokenizer(cfg)
+    tokenizer = make_tokenizer(cfg)
 
     logging.info(
         f"Filtering with Casanovo config: {casanovo_config} "
@@ -678,7 +678,7 @@ def _filter_mgf_files(
                     n_bad_seq += 1
                     continue
 
-                charge = _parse_charge(spectrum["params"].get("charge"))
+                charge = parse_charge(spectrum["params"].get("charge"))
                 if charge is None or charge <= 0 or charge > max_charge:
                     n_bad_charge += 1
                     continue

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -725,6 +725,7 @@ def create_datasets(
     combine_with_existing: bool = False,
     mskb_format: bool = False,
     casanovo_config: Optional[PathLike] = None,
+    tmp_dir: Optional[PathLike] = None,
 ) -> None:
     """Create peptide-level train/validation/test splits from annotated MGF files.
 
@@ -801,6 +802,11 @@ def create_datasets(
         charge, or fewer than ``min_peaks`` peaks are removed. Filtering is
         applied after any MassIVE-KB conversion. Per-criterion counts are
         written to the log file.
+    tmp_dir : PathLike, optional
+        Directory to use for temporary files (converted and filtered MGFs).
+        Defaults to the system temporary directory (usually ``/tmp``). Set
+        this to a directory on a volume with sufficient free space when
+        processing large MGF files.
     """
     if not mgf_files:
         raise ValueError("At least one MGF file must be provided.")
@@ -841,7 +847,7 @@ def create_datasets(
     try:
         random.seed(random_seed)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(dir=tmp_dir) as tmpdir:
             tmp = pathlib.Path(tmpdir)
             if mskb_format:
                 converted = []

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -836,7 +836,9 @@ def create_datasets(
     try:
         random.seed(random_seed)
 
-        with tempfile.TemporaryDirectory(dir=tmp_dir, ignore_cleanup_errors=True) as tmpdir:
+        with tempfile.TemporaryDirectory(
+            dir=tmp_dir, ignore_cleanup_errors=True
+        ) as tmpdir:
             tmp = pathlib.Path(tmpdir)
             if mskb_format:
                 converted = []

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -13,7 +13,7 @@ import pyteomics.mgf
 import tqdm
 
 from . import configure_logging
-from .filter_spectra import _load_config, _parse_charge, _seq_to_tokens
+from .filter_spectra import _load_config, _make_tokenizer, _parse_charge
 from .mskb2proforma import convert as _mskb2proforma_convert
 from .types import Commands
 
@@ -644,13 +644,7 @@ def _filter_mgf_files(
     cfg = _load_config(casanovo_config)
     min_peaks: int = cfg.get("min_peaks", 20)
     max_charge: int = cfg.get("max_charge", 10)
-    replace_il: bool = cfg.get("replace_isoleucine_with_leucine", False)
-
-    _STANDARD_AAS = set("ACDEFGHIKLMNPQRSTVWY")
-    residues: dict = cfg.get("residues", {})
-    valid_tokens: set[str] = _STANDARD_AAS | set(residues.keys())
-    if replace_il:
-        valid_tokens.discard("I")
+    tokenizer = _make_tokenizer(cfg)
 
     logging.info(
         f"Filtering with Casanovo config: {casanovo_config} "
@@ -679,13 +673,8 @@ def _filter_mgf_files(
                     continue
 
                 try:
-                    tokens = _seq_to_tokens(seq)
-                except Exception:  # noqa: BLE001
-                    n_bad_seq += 1
-                    continue
-                if replace_il:
-                    tokens = ["L" + t[1:] if t[0] == "I" else t for t in tokens]
-                if any(t not in valid_tokens for t in tokens):
+                    tokenizer.tokenize(seq)
+                except ValueError:
                     n_bad_seq += 1
                     continue
 

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -663,43 +663,44 @@ def _filter_mgf_files(
     for i, src in enumerate(mgf_files):
         src = pathlib.Path(src)
         dst = tmpdir / f"filtered_{i}_{src.name}"
-        spectra_out = []
 
-        for spectrum in tqdm.tqdm(
-            pyteomics.mgf.read(str(src), use_index=False),
-            desc=f"Filtering {src.name}",
-            unit="psm",
-        ):
-            n_total += 1
+        def _passing(path):
+            nonlocal n_total, n_no_seq, n_bad_seq, n_bad_charge, n_few_peaks
+            for spectrum in tqdm.tqdm(
+                pyteomics.mgf.read(str(path), use_index=False),
+                desc=f"Filtering {path.name}",
+                unit="psm",
+            ):
+                n_total += 1
 
-            seq = spectrum["params"].get("seq", "")
-            if not seq:
-                n_no_seq += 1
-                continue
+                seq = spectrum["params"].get("seq", "")
+                if not seq:
+                    n_no_seq += 1
+                    continue
 
-            try:
-                tokens = _seq_to_tokens(seq)
-            except Exception:  # noqa: BLE001
-                n_bad_seq += 1
-                continue
-            if replace_il:
-                tokens = [t.replace("I", "L") for t in tokens]
-            if any(t not in valid_tokens for t in tokens):
-                n_bad_seq += 1
-                continue
+                try:
+                    tokens = _seq_to_tokens(seq)
+                except Exception:  # noqa: BLE001
+                    n_bad_seq += 1
+                    continue
+                if replace_il:
+                    tokens = ["L" + t[1:] if t[0] == "I" else t for t in tokens]
+                if any(t not in valid_tokens for t in tokens):
+                    n_bad_seq += 1
+                    continue
 
-            charge = _parse_charge(spectrum["params"].get("charge"))
-            if charge is None or charge <= 0 or charge > max_charge:
-                n_bad_charge += 1
-                continue
+                charge = _parse_charge(spectrum["params"].get("charge"))
+                if charge is None or charge <= 0 or charge > max_charge:
+                    n_bad_charge += 1
+                    continue
 
-            if len(spectrum.get("m/z array", [])) < min_peaks:
-                n_few_peaks += 1
-                continue
+                if len(spectrum.get("m/z array", [])) < min_peaks:
+                    n_few_peaks += 1
+                    continue
 
-            spectra_out.append(spectrum)
+                yield spectrum
 
-        pyteomics.mgf.write(spectra_out, output=str(dst))
+        pyteomics.mgf.write(_passing(src), output=str(dst))
         filtered.append(dst)
 
     n_pass = n_total - n_no_seq - n_bad_seq - n_bad_charge - n_few_peaks

--- a/src/casanovoutils/datasets.py
+++ b/src/casanovoutils/datasets.py
@@ -836,7 +836,7 @@ def create_datasets(
     try:
         random.seed(random_seed)
 
-        with tempfile.TemporaryDirectory(dir=tmp_dir) as tmpdir:
+        with tempfile.TemporaryDirectory(dir=tmp_dir, ignore_cleanup_errors=True) as tmpdir:
             tmp = pathlib.Path(tmpdir)
             if mskb_format:
                 converted = []

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -1,0 +1,264 @@
+"""
+Filter an annotated MGF file using the same criteria applied by Casanovo.
+
+Removes spectra that would be silently skipped or crash Casanovo during
+training:
+
+* Missing or empty ``SEQ`` field.
+* Sequence contains tokens not present in the Casanovo residue vocabulary.
+* Precursor charge is missing, ambiguous, or exceeds ``max_charge``.
+* Spectrum has fewer than ``min_peaks`` peaks (before any Casanovo
+  peak-intensity filtering).
+
+Outputs a filtered MGF and a log file with per-criterion counts.
+"""
+
+import logging
+import pathlib
+from os import PathLike
+from typing import Generator, Optional
+
+import pyteomics.mgf
+import tqdm
+import yaml
+from pyteomics import proforma as pf
+
+from . import configure_logging
+from .types import PyteomicsSpectrum
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_config(config_path: PathLike) -> dict:
+    """Load a Casanovo YAML config and return it as a dict."""
+    with open(config_path) as fh:
+        cfg = yaml.safe_load(fh)
+    if cfg is None:
+        return {}
+    if not isinstance(cfg, dict):
+        raise ValueError(
+            f"Expected a YAML mapping in {config_path!r}, got {type(cfg).__name__}."
+        )
+    return cfg
+
+
+def _seq_to_tokens(seq: str) -> list[str]:
+    """
+    Split a ProForma sequence into tokens using the same format as
+    depthcharge's ``PeptideTokenizer.split()``.
+
+    Named modifications produce tokens like ``C[Carbamidomethyl]`` and
+    ``[Acetyl]-``; mass modifications produce tokens like
+    ``K[+229.163000]`` and ``[+271.174000]-``.
+
+    Raises an exception if the ProForma string cannot be parsed.
+    """
+    residues, meta = pf.parse(seq)
+
+    def _mod_str(mods: list) -> str:
+        """Format a list of pyteomics modification objects as ``[...]``."""
+        if len(mods) == 1:
+            try:
+                return f"[{mods[0].name}]"
+            except (AttributeError, ValueError):
+                return f"[{mods[0].mass:+0.6f}]"
+        # Multiple mods: sum masses.
+        total = sum(m.mass for m in mods)
+        return f"[{total:+0.6f}]"
+
+    tokens: list[str] = []
+
+    # N-terminal modification.
+    n_term = meta.get("n_term")
+    if n_term:
+        tokens.append(f"{_mod_str(n_term)}-")
+
+    # Residues.
+    for aa, mods in residues:
+        if mods:
+            tokens.append(f"{aa}{_mod_str(mods)}")
+        else:
+            tokens.append(aa)
+
+    # C-terminal modification.
+    c_term = meta.get("c_term")
+    if c_term:
+        tokens.append(f"-{_mod_str(c_term)}")
+
+    return tokens
+
+
+def _parse_charge(charge_raw) -> Optional[int]:
+    """
+    Return the charge as a positive int, or ``None`` if it is missing,
+    ambiguous, zero, or cannot be converted.
+    """
+    try:
+        if isinstance(charge_raw, list):
+            if len(charge_raw) != 1:
+                return None
+            return int(charge_raw[0])
+        return int(charge_raw)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Core command
+# ---------------------------------------------------------------------------
+
+
+def filter_spectra(
+    mgf_file: PathLike,
+    config: PathLike,
+    output_root: str = "filtered",
+    output_dir: PathLike = ".",
+    overwrite: bool = False,
+) -> None:
+    """
+    Filter an annotated MGF file using Casanovo's spectrum acceptance criteria.
+
+    Reads *mgf_file*, removes spectra that Casanovo would reject, and writes
+    the survivors to ``<output_dir>/<output_root>.mgf``.  A summary of how
+    many spectra were removed by each criterion is written to
+    ``<output_dir>/<output_root>.log``.
+
+    Parameters
+    ----------
+    mgf_file : PathLike
+        Input annotated MGF file.
+    config : PathLike
+        Casanovo YAML configuration file.  The fields ``residues``,
+        ``replace_isoleucine_with_leucine``, ``min_peaks``, and
+        ``max_charge`` are read from this file.
+    output_root : str, optional
+        Stem used for output file names (default ``"filtered"``).
+    output_dir : PathLike, optional
+        Directory in which to write output files (default: current directory).
+    overwrite : bool, optional
+        If False (default), raise ``FileExistsError`` if any output file
+        already exists.
+    """
+    output_dir = pathlib.Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    mgf_out = output_dir / f"{output_root}.mgf"
+    log_out = output_dir / f"{output_root}.log"
+
+    if not overwrite:
+        existing = [p for p in (mgf_out, log_out) if p.exists()]
+        if existing:
+            paths = ", ".join(str(p) for p in existing)
+            raise FileExistsError(
+                f"Output file(s) already exist: {paths}. "
+                f"Use --overwrite to overwrite."
+            )
+
+    # Always attach a file handler for log_out, even if root handlers exist
+    # from a prior configure_logging call.
+    configure_logging(log_out)
+    if not any(
+        isinstance(h, logging.FileHandler) and h.baseFilename == str(log_out.resolve())
+        for h in logging.root.handlers
+    ):
+        file_handler = logging.FileHandler(log_out)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+        )
+        logging.root.addHandler(file_handler)
+
+    cfg = _load_config(config)
+    min_peaks: int = cfg.get("min_peaks", 20)
+    max_charge: int = cfg.get("max_charge", 10)
+    replace_il: bool = cfg.get("replace_isoleucine_with_leucine", False)
+
+    # Build the valid-token set from the config residues, mirroring
+    # PeptideTokenizer: always include the 20 standard amino acids, then
+    # add (or override with) whatever is in the config.
+    _STANDARD_AAS = set("ACDEFGHIKLMNPQRSTVWY")
+    residues: dict = cfg.get("residues", {})
+    valid_tokens: set[str] = _STANDARD_AAS | set(residues.keys())
+    # When I→L replacement is active, I is not a valid token; sequences
+    # containing I are canonicalized to L before vocabulary lookup.
+    if replace_il:
+        valid_tokens.discard("I")
+
+    logger.info("Input MGF  : %s", mgf_file)
+    logger.info("Config     : %s", config)
+    logger.info("min_peaks  : %d", min_peaks)
+    logger.info("max_charge : %d", max_charge)
+    logger.info("Output MGF : %s", mgf_out)
+
+    n_total = 0
+    n_no_seq = 0
+    n_bad_seq = 0
+    n_bad_charge = 0
+    n_few_peaks = 0
+    n_pass = 0
+
+    def _filtered_spectra() -> Generator[PyteomicsSpectrum, None, None]:
+        nonlocal n_total, n_no_seq, n_bad_seq, n_bad_charge, n_few_peaks, n_pass
+
+        for spectrum in tqdm.tqdm(
+            pyteomics.mgf.read(str(mgf_file), use_index=False),
+            desc=f"Filtering {mgf_file}",
+            unit="psm",
+        ):
+            n_total += 1
+
+            # --- 1. Missing or empty SEQ ------------------------------------
+            seq = spectrum["params"].get("seq", "")
+            if not seq:
+                n_no_seq += 1
+                continue
+
+            # --- 2. Unknown tokens in sequence ------------------------------
+            try:
+                tokens = _seq_to_tokens(seq)
+            except Exception:  # noqa: BLE001 — pyteomics raises heterogeneous types
+                n_bad_seq += 1
+                continue
+            # When replace_isoleucine_with_leucine is set, canonicalize I→L
+            # in tokens before vocabulary lookup, matching Casanovo's behavior.
+            if replace_il:
+                tokens = [t.replace("I", "L") for t in tokens]
+            if any(t not in valid_tokens for t in tokens):
+                n_bad_seq += 1
+                continue
+
+            # --- 3. Invalid charge ------------------------------------------
+            charge = _parse_charge(spectrum["params"].get("charge"))
+            if charge is None or charge <= 0 or charge > max_charge:
+                n_bad_charge += 1
+                continue
+
+            # --- 4. Too few peaks -------------------------------------------
+            if len(spectrum.get("m/z array", [])) < min_peaks:
+                n_few_peaks += 1
+                continue
+
+            n_pass += 1
+            yield spectrum
+
+    pyteomics.mgf.write(
+        tqdm.tqdm(_filtered_spectra(), desc=f"Writing {mgf_out}", unit="psm"),
+        output=str(mgf_out),
+    )
+
+    n_filtered = n_total - n_pass
+    logger.info("---")
+    logger.info("Total spectra read        : %d", n_total)
+    logger.info("Filtered: missing SEQ     : %d", n_no_seq)
+    logger.info("Filtered: invalid tokens  : %d", n_bad_seq)
+    logger.info("Filtered: invalid charge  : %d", n_bad_charge)
+    logger.info("Filtered: too few peaks   : %d", n_few_peaks)
+    logger.info("Filtered: total           : %d", n_filtered)
+    logger.info("Passing spectra written   : %d", n_pass)
+
+
+COMMANDS = filter_spectra

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _load_config(config_path: PathLike) -> dict:
+def load_config(config_path: PathLike) -> dict:
     """Load a Casanovo YAML config and return it as a dict."""
     with open(config_path) as fh:
         cfg = yaml.safe_load(fh)
@@ -47,7 +47,7 @@ def _load_config(config_path: PathLike) -> dict:
     return cfg
 
 
-def _make_tokenizer(cfg: dict) -> PeptideTokenizer:
+def make_tokenizer(cfg: dict) -> PeptideTokenizer:
     """Build a PeptideTokenizer from the residues in a Casanovo config."""
     return PeptideTokenizer(
         residues=cfg.get("residues", {}),
@@ -57,7 +57,7 @@ def _make_tokenizer(cfg: dict) -> PeptideTokenizer:
     )
 
 
-def _parse_charge(charge_raw) -> Optional[int]:
+def parse_charge(charge_raw) -> Optional[int]:
     """
     Return the charge as a positive int, or ``None`` if it is missing,
     ambiguous, zero, or cannot be converted.
@@ -123,23 +123,12 @@ def filter_spectra(
                 f"Use --overwrite to overwrite."
             )
 
-    # Always attach a file handler for log_out, even if root handlers exist
-    # from a prior configure_logging call.
     configure_logging(log_out)
-    if not any(
-        isinstance(h, logging.FileHandler) and h.baseFilename == str(log_out.resolve())
-        for h in logging.root.handlers
-    ):
-        file_handler = logging.FileHandler(log_out)
-        file_handler.setFormatter(
-            logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
-        )
-        logging.root.addHandler(file_handler)
 
-    cfg = _load_config(config)
+    cfg = load_config(config)
     min_peaks: int = cfg.get("min_peaks", 20)
     max_charge: int = cfg.get("max_charge", 10)
-    tokenizer = _make_tokenizer(cfg)
+    tokenizer = make_tokenizer(cfg)
 
     logger.info("Input MGF  : %s", mgf_file)
     logger.info("Config     : %s", config)
@@ -178,7 +167,7 @@ def filter_spectra(
                 continue
 
             # --- 3. Invalid charge ------------------------------------------
-            charge = _parse_charge(spectrum["params"].get("charge"))
+            charge = parse_charge(spectrum["params"].get("charge"))
             if charge is None or charge <= 0 or charge > max_charge:
                 n_bad_charge += 1
                 continue

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -129,6 +129,7 @@ def filter_spectra(
     min_peaks: int = cfg.get("min_peaks", 20)
     max_charge: int = cfg.get("max_charge", 10)
     tokenizer = make_tokenizer(cfg)
+    vocab: set[str] = set(cfg.get("residues", {}).keys())
 
     logger.info("Input MGF  : %s", mgf_file)
     logger.info("Config     : %s", config)
@@ -160,9 +161,18 @@ def filter_spectra(
                 continue
 
             # --- 2. Unknown tokens in sequence ------------------------------
+            # Use split() to get ProForma-aware tokens, then check each
+            # strictly against the configured vocabulary.  tokenize() accepts
+            # standard AAs regardless of the configured residues dict, so it
+            # would allow e.g. bare "C" even when only "C[Carbamidomethyl]"
+            # is in the vocabulary.  split() raises ProFormaError for
+            # malformed sequences and ValueError for other parse failures.
             try:
-                tokenizer.tokenize(seq)
-            except ValueError:
+                tokens = tokenizer.split(seq)
+            except Exception:
+                n_bad_seq += 1
+                continue
+            if not all(tok in vocab for tok in tokens):
                 n_bad_seq += 1
                 continue
 

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -21,7 +21,7 @@ from typing import Generator, Optional
 import pyteomics.mgf
 import tqdm
 import yaml
-from pyteomics import proforma as pf
+from depthcharge.tokenizers import PeptideTokenizer
 
 from . import configure_logging
 from .types import PyteomicsSpectrum
@@ -47,50 +47,14 @@ def _load_config(config_path: PathLike) -> dict:
     return cfg
 
 
-def _seq_to_tokens(seq: str) -> list[str]:
-    """
-    Split a ProForma sequence into tokens using the same format as
-    depthcharge's ``PeptideTokenizer.split()``.
-
-    Named modifications produce tokens like ``C[Carbamidomethyl]`` and
-    ``[Acetyl]-``; mass modifications produce tokens like
-    ``K[+229.163000]`` and ``[+271.174000]-``.
-
-    Raises an exception if the ProForma string cannot be parsed.
-    """
-    residues, meta = pf.parse(seq)
-
-    def _mod_str(mods: list) -> str:
-        """Format a list of pyteomics modification objects as ``[...]``."""
-        if len(mods) == 1:
-            try:
-                return f"[{mods[0].name}]"
-            except (AttributeError, ValueError):
-                return f"[{mods[0].mass:+0.6f}]"
-        # Multiple mods: sum masses.
-        total = sum(m.mass for m in mods)
-        return f"[{total:+0.6f}]"
-
-    tokens: list[str] = []
-
-    # N-terminal modification.
-    n_term = meta.get("n_term")
-    if n_term:
-        tokens.append(f"{_mod_str(n_term)}-")
-
-    # Residues.
-    for aa, mods in residues:
-        if mods:
-            tokens.append(f"{aa}{_mod_str(mods)}")
-        else:
-            tokens.append(aa)
-
-    # C-terminal modification.
-    c_term = meta.get("c_term")
-    if c_term:
-        tokens.append(f"-{_mod_str(c_term)}")
-
-    return tokens
+def _make_tokenizer(cfg: dict) -> PeptideTokenizer:
+    """Build a PeptideTokenizer from the residues in a Casanovo config."""
+    return PeptideTokenizer(
+        residues=cfg.get("residues", {}),
+        replace_isoleucine_with_leucine=cfg.get(
+            "replace_isoleucine_with_leucine", False
+        ),
+    )
 
 
 def _parse_charge(charge_raw) -> Optional[int]:
@@ -175,18 +139,7 @@ def filter_spectra(
     cfg = _load_config(config)
     min_peaks: int = cfg.get("min_peaks", 20)
     max_charge: int = cfg.get("max_charge", 10)
-    replace_il: bool = cfg.get("replace_isoleucine_with_leucine", False)
-
-    # Build the valid-token set from the config residues, mirroring
-    # PeptideTokenizer: always include the 20 standard amino acids, then
-    # add (or override with) whatever is in the config.
-    _STANDARD_AAS = set("ACDEFGHIKLMNPQRSTVWY")
-    residues: dict = cfg.get("residues", {})
-    valid_tokens: set[str] = _STANDARD_AAS | set(residues.keys())
-    # When I→L replacement is active, I is not a valid token; sequences
-    # containing I are canonicalized to L before vocabulary lookup.
-    if replace_il:
-        valid_tokens.discard("I")
+    tokenizer = _make_tokenizer(cfg)
 
     logger.info("Input MGF  : %s", mgf_file)
     logger.info("Config     : %s", config)
@@ -219,15 +172,8 @@ def filter_spectra(
 
             # --- 2. Unknown tokens in sequence ------------------------------
             try:
-                tokens = _seq_to_tokens(seq)
-            except Exception:  # noqa: BLE001 — pyteomics raises heterogeneous types
-                n_bad_seq += 1
-                continue
-            # When replace_isoleucine_with_leucine is set, canonicalize I→L
-            # in tokens before vocabulary lookup, matching Casanovo's behavior.
-            if replace_il:
-                tokens = ["L" + t[1:] if t[0] == "I" else t for t in tokens]
-            if any(t not in valid_tokens for t in tokens):
+                tokenizer.tokenize(seq)
+            except ValueError:
                 n_bad_seq += 1
                 continue
 

--- a/src/casanovoutils/filter_spectra.py
+++ b/src/casanovoutils/filter_spectra.py
@@ -226,7 +226,7 @@ def filter_spectra(
             # When replace_isoleucine_with_leucine is set, canonicalize I→L
             # in tokens before vocabulary lookup, matching Casanovo's behavior.
             if replace_il:
-                tokens = [t.replace("I", "L") for t in tokens]
+                tokens = ["L" + t[1:] if t[0] == "I" else t for t in tokens]
             if any(t not in valid_tokens for t in tokens):
                 n_bad_seq += 1
                 continue

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1330,3 +1330,183 @@ class TestCreateDatasetsEnhancements:
         assert "CPEPTLDE" in bare_seqs
         for bare in bare_seqs:
             assert "[" not in bare
+
+
+# ---------------------------------------------------------------------------
+# Tests for casanovo_config filtering path in create_datasets
+# ---------------------------------------------------------------------------
+
+
+def _write_casanovo_config(path, *, residues=None, min_peaks=2, max_charge=5):
+    """Write a minimal Casanovo YAML config for testing."""
+    import yaml
+
+    if residues is None:
+        residues = {}  # uses depthcharge default vocabulary
+    cfg = {
+        "residues": residues,
+        "min_peaks": min_peaks,
+        "max_charge": max_charge,
+        "replace_isoleucine_with_leucine": False,
+    }
+    path.write_text(yaml.dump(cfg))
+    return path
+
+
+# 19 unique valid peptide sequences (standard amino acids only).
+_VALID_SEQS = [
+    "ACDEF",
+    "GHIKL",
+    "MNPQR",
+    "STVWY",
+    "AACDE",
+    "GHILK",
+    "MNPQY",
+    "STVWI",
+    "AAGDE",
+    "GHIKM",
+    "MNPRY",
+    "STVWK",
+    "AAKDE",
+    "GHIML",
+    "MNRQY",
+    "STVWM",
+    "AALEF",
+    "GHILN",
+    "MNPVY",
+]
+
+
+def _write_mgf_with_charge_field(path, spectra):
+    """Write spectra with explicit charge fields.
+
+    Parameters
+    ----------
+    spectra : list[tuple[str, int, list[float], list[float]]]
+        Each element is (seq, charge, mz_values, intensity_values).
+    """
+    import numpy as np
+
+    records = []
+    for seq, charge, mz, intensity in spectra:
+        record = {
+            "params": {"seq": seq, "pepmass": (500.0,), "charge": [charge]},
+            "m/z array": np.array(mz),
+            "intensity array": np.array(intensity),
+        }
+        records.append(record)
+    pyteomics.mgf.write(records, output=str(path))
+    return str(path)
+
+
+def _spectra_with_charge(seqs, charge=2, n_peaks=3):
+    """Return (seq, charge, mz_list, intensity_list) tuples for ``seqs``."""
+    mz = list(range(100, 100 + n_peaks * 10, 10))
+    inten = [1.0] * n_peaks
+    return [(s, charge, mz, inten) for s in seqs]
+
+
+class TestCasanovoConfigFilter:
+    """Tests for create_datasets with casanovo_config filtering."""
+
+    def _all_seqs(self, tmp_path, root="out"):
+        seqs = set()
+        for split in ("train", "val", "test"):
+            seqs.update(_get_peptides(_read_mgf(tmp_path / f"{root}.{split}.mgf")))
+        return seqs
+
+    def test_invalid_tokens_filtered(self, tmp_path):
+        """Spectra with tokens outside the config vocabulary are excluded."""
+        cfg = _write_casanovo_config(tmp_path / "config.yaml")
+        # "BBBB" contains B, which is not a standard amino acid.
+        spectra = [("BBBB", 2, [100.0, 200.0, 300.0], [1.0, 1.0, 1.0])]
+        spectra += _spectra_with_charge(_VALID_SEQS)
+        mgf = _write_mgf_with_charge_field(tmp_path / "input.mgf", spectra)
+
+        create_datasets(mgf, output_root=str(tmp_path / "out"), casanovo_config=cfg)
+
+        assert "BBBB" not in self._all_seqs(tmp_path)
+
+    def test_valid_spectra_pass_through(self, tmp_path):
+        """Spectra that meet all criteria appear in the output."""
+        cfg = _write_casanovo_config(tmp_path / "config.yaml")
+        mgf = _write_mgf_with_charge_field(
+            tmp_path / "input.mgf",
+            _spectra_with_charge(_VALID_SEQS + ["ACDEFG"]),
+        )
+
+        create_datasets(mgf, output_root=str(tmp_path / "out"), casanovo_config=cfg)
+
+        seqs = self._all_seqs(tmp_path)
+        assert all(s in seqs for s in _VALID_SEQS)
+
+    def test_too_few_peaks_filtered(self, tmp_path):
+        """Spectra with fewer than min_peaks peaks are excluded."""
+        cfg = _write_casanovo_config(tmp_path / "config.yaml", min_peaks=3)
+        # "ACDEF" has only 1 peak — fewer than min_peaks=3.
+        spectra = [("ACDEF", 2, [100.0], [1.0])]
+        spectra += _spectra_with_charge(_VALID_SEQS[1:])
+        mgf = _write_mgf_with_charge_field(tmp_path / "input.mgf", spectra)
+
+        create_datasets(mgf, output_root=str(tmp_path / "out"), casanovo_config=cfg)
+
+        assert "ACDEF" not in self._all_seqs(tmp_path)
+
+    def test_bad_charge_filtered(self, tmp_path):
+        """Spectra with charge above max_charge are excluded."""
+        cfg = _write_casanovo_config(tmp_path / "config.yaml", max_charge=3)
+        # charge=6 exceeds max_charge=3.
+        spectra = [("ACDEF", 6, [100.0, 200.0, 300.0], [1.0, 1.0, 1.0])]
+        spectra += _spectra_with_charge(_VALID_SEQS[1:])
+        mgf = _write_mgf_with_charge_field(tmp_path / "input.mgf", spectra)
+
+        create_datasets(mgf, output_root=str(tmp_path / "out"), casanovo_config=cfg)
+
+        assert "ACDEF" not in self._all_seqs(tmp_path)
+
+    def test_missing_seq_filtered(self, tmp_path):
+        """Spectra with a missing SEQ field are excluded."""
+        import numpy as np
+
+        cfg = _write_casanovo_config(tmp_path / "config.yaml")
+        records = [
+            {
+                "params": {"pepmass": (500.0,), "charge": [2]},  # no "seq" key
+                "m/z array": np.array([100.0, 200.0, 300.0]),
+                "intensity array": np.array([1.0, 1.0, 1.0]),
+            }
+        ]
+        records += [
+            {
+                "params": {"seq": s, "pepmass": (500.0,), "charge": [2]},
+                "m/z array": np.array([100.0, 200.0, 300.0]),
+                "intensity array": np.array([1.0, 1.0, 1.0]),
+            }
+            for s in _VALID_SEQS
+        ]
+        pyteomics.mgf.write(records, output=str(tmp_path / "input.mgf"))
+
+        create_datasets(
+            str(tmp_path / "input.mgf"),
+            output_root=str(tmp_path / "out"),
+            casanovo_config=cfg,
+        )
+
+        seqs = self._all_seqs(tmp_path)
+        assert all(s in seqs for s in _VALID_SEQS)
+
+    def test_only_valid_spectra_contribute_to_splits(self, tmp_path):
+        """Split counts reflect the filtered set, not the raw input."""
+        cfg = _write_casanovo_config(tmp_path / "config.yaml")
+        # 1 invalid-token spectrum ("BBBB") + len(_VALID_SEQS) valid spectra.
+        spectra = [("BBBB", 2, [100.0, 200.0, 300.0], [1.0, 1.0, 1.0])]
+        spectra += _spectra_with_charge(_VALID_SEQS)
+        mgf = _write_mgf_with_charge_field(tmp_path / "input.mgf", spectra)
+
+        create_datasets(mgf, output_root=str(tmp_path / "out"), casanovo_config=cfg)
+
+        total = sum(
+            len(_read_mgf(tmp_path / f"out.{split}.mgf"))
+            for split in ("train", "val", "test")
+        )
+        assert total == len(_VALID_SEQS)


### PR DESCRIPTION
## Summary

- Adds an optional `--casanovo_config` parameter to `casanovoutils datasets` (i.e. `create_datasets`)
- When provided, spectra are filtered before any splitting using the vocabulary and thresholds from the Casanovo YAML config (`residues`, `min_peaks`, `max_charge`, `replace_isoleucine_with_leucine`)
- Filtering runs after MassIVE-KB conversion (if `--mskb_format`) but before peptide counting and split assignment, so invalid spectra never influence split ratios or peptide grouping
- Filtered temp MGFs are written into the existing `TemporaryDirectory`, so no extra disk management is needed
- Per-criterion counts (missing SEQ, invalid tokens, bad charge, too few peaks) are written to the same `<output_root>.log.txt`
- When `--casanovo_config` is not provided, behaviour is completely unchanged
- Includes `filter_spectra.py` from PR #46; the copy will be removed when that PR merges into the base branch

## Depends on
- PR #42 (improve-logging) — base branch
- PR #46 (filter-spectra) — provides `filter_spectra.py`; copy included here until merge

## Test plan

- [ ] Run `casanovoutils datasets <mgf> --output_root=out --casanovo_config=<config.yaml>` and confirm the log reports per-criterion filtered counts
- [ ] Confirm spectra with `K[+229.163]`-style mods are filtered before splitting
- [ ] Confirm that without `--casanovo_config` the output is identical to the current behaviour
- [ ] Confirm filtering happens after MassIVE-KB conversion when `--mskb_format` is also set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable filtering for annotated MGF spectra before dataset splitting.
  * Filters spectra with missing sequences, invalid residues or charges, and too few peaks.
  * Added optional isoleucine-to-leucine canonicalization.
  * Added a command to filter spectra and save results to a separate output file.
* **Improvements**
  * Filtering reports exclusion counts and protects existing outputs unless overwrite is enabled.
  * Dataset creation optionally accepts Casanovo filtering configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->