### PR TITLE
Add spectrum and mirror plotting commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pyteomics>=4.7.5",
     "pyyaml>=6.0.3",
     "seaborn>=0.13.2",
+    "spectrum-utils>=0.4.2",
     "tabulate>=0.10.0",
     "tqdm>=4.67.1",
 ]

--- a/src/casanovoutils/constants.py
+++ b/src/casanovoutils/constants.py
@@ -24,6 +24,8 @@ class Constants:
     coverage_column : str
         Name of the column holding cumulative coverage values computed
         by ``calc_precision_coverage``.
+    proforma_column : str
+        Name of the mzTab column holding the ProForma peptidoform sequence.
     min_score : float
         Sentinel score assigned to gap positions during sequence alignment.
     """
@@ -34,6 +36,9 @@ class Constants:
     aa_idx_column: str = "pc_aa_idx"
     precision_column: str = "pc_precision"
     coverage_column: str = "pc_coverage"
+    proforma_column: str = (
+        "mztab_opt_global_cv_MS:1003169_proforma_peptidoform_sequence"
+    )
     predicted_tokens: str = "mztab_tokens"
     ground_truth_tokens: str = "mgf_tokens"
     min_score: float = -1.0

--- a/src/casanovoutils/plot.py
+++ b/src/casanovoutils/plot.py
@@ -1,6 +1,7 @@
 """Plot annotated spectra and mirror plots from Casanovo mzTab results."""
 
 import sys
+import warnings
 
 import matplotlib.pyplot as plt
 import polars as pl
@@ -9,10 +10,9 @@ import pyteomics.mzml
 import spectrum_utils.plot as sup
 import spectrum_utils.spectrum as sus
 
+from .constants import Constants
 from .denovoutils import DfPath, get_mztab_df
 from .types import Commands
-
-_PROFORMA_COLUMN = "mztab_opt_global_cv_MS:1003169_proforma_peptidoform_sequence"
 
 
 def _read_spectrum(peak_file: str, index: int) -> sus.MsmsSpectrum:
@@ -40,14 +40,27 @@ def _read_spectrum(peak_file: str, index: int) -> sus.MsmsSpectrum:
             "selectedIon"
         ][0]
         precursor_mz = float(ion["selected ion m/z"])
-        precursor_charge = int(ion.get("charge state", 0))
+        charge = ion.get("charge state")
     else:
         with pyteomics.mgf.IndexedMGF(peak_file) as reader:
             spectrum = reader[index]
         params = spectrum["params"]
-        precursor_mz = float(params["pepmass"][0])
-        charge = params.get("charge")
-        precursor_charge = int(charge[0]) if charge else 0
+        pepmass = params["pepmass"]
+        # pepmass is a (m/z, intensity) tuple, but the intensity may be
+        # absent; only index into it when there are multiple values.
+        precursor_mz = float(
+            pepmass[0] if isinstance(pepmass, (list, tuple)) else pepmass
+        )
+        mgf_charge = params.get("charge")
+        charge = mgf_charge[0] if mgf_charge else None
+
+    if charge is None:
+        warnings.warn(
+            f"No precursor charge for spectrum index {index}; defaulting to 0."
+        )
+        precursor_charge = 0
+    else:
+        precursor_charge = int(charge)
     return sus.MsmsSpectrum(
         str(index),
         precursor_mz,
@@ -74,13 +87,19 @@ def _peptide_at_index(mztab_df: pl.DataFrame, index: int) -> str:
         The ProForma peptide string for the matching PSM.
     """
     column = (
-        _PROFORMA_COLUMN if _PROFORMA_COLUMN in mztab_df.columns else "mztab_sequence"
+        Constants.proforma_column
+        if Constants.proforma_column in mztab_df.columns
+        else "mztab_sequence"
     )
     matches = mztab_df.filter(
         pl.col("mztab_spectra_ref").str.ends_with(f"index={index}")
     )
     if matches.is_empty():
         raise ValueError(f"No PSM found for spectrum index {index}")
+    if matches.height > 1:
+        warnings.warn(
+            f"Multiple PSMs found for spectrum index {index}; using the first."
+        )
     return matches[column][0]
 
 
@@ -91,12 +110,19 @@ def _annotated_spectrum(
     fragment_tol: float,
     fragment_tol_mode: str,
     ion_types: str,
+    max_charge: int | None,
+    max_isotope: int,
 ) -> sus.MsmsSpectrum:
     """Build the annotated spectrum for a PSM in an mzTab file."""
     peptide = _peptide_at_index(get_mztab_df(mztab), index)
     spectrum = _read_spectrum(peak_file, index)
     spectrum.annotate_proforma(
-        peptide, fragment_tol, fragment_tol_mode, ion_types=ion_types
+        peptide,
+        fragment_tol,
+        fragment_tol_mode,
+        ion_types=ion_types,
+        max_isotope=max_isotope,
+        max_ion_charge=max_charge,
     )
     return spectrum
 
@@ -109,6 +135,9 @@ def spectrum(
     fragment_tol: float = 0.5,
     fragment_tol_mode: str = "Da",
     ion_types: str = "by",
+    max_charge: int | None = None,
+    max_isotope: int = 0,
+    title: str | None = None,
 ) -> None:
     """
     Plot a single annotated spectrum from a Casanovo mzTab result.
@@ -130,12 +159,28 @@ def spectrum(
         Fragment mass tolerance mode, ``"Da"`` or ``"ppm"``.
     ion_types : str
         Fragment ion types to annotate, e.g. ``"by"``.
+    max_charge : int or None
+        Maximum fragment ion charge to annotate. ``None`` uses the
+        spectrum_utils default (the precursor charge).
+    max_isotope : int
+        Maximum isotope number to annotate for each fragment ion.
+    title : str or None
+        Optional title for the plot.
     """
     spec = _annotated_spectrum(
-        mztab, peak_file, index, fragment_tol, fragment_tol_mode, ion_types
+        mztab,
+        peak_file,
+        index,
+        fragment_tol,
+        fragment_tol_mode,
+        ion_types,
+        max_charge,
+        max_isotope,
     )
     fig, ax = plt.subplots(figsize=(12, 6))
     sup.spectrum(spec, ax=ax)
+    if title is not None:
+        ax.set_title(title)
     fig.savefig(out, dpi=300, bbox_inches="tight")
     plt.close(fig)
     print(f"Wrote {out}", file=sys.stderr)
@@ -150,6 +195,9 @@ def mirror(
     fragment_tol: float = 0.5,
     fragment_tol_mode: str = "Da",
     ion_types: str = "by",
+    max_charge: int | None = None,
+    max_isotope: int = 0,
+    title: str | None = None,
 ) -> None:
     """
     Plot a mirror plot of a predicted versus a ground truth annotation.
@@ -176,9 +224,24 @@ def mirror(
         Fragment mass tolerance mode, ``"Da"`` or ``"ppm"``.
     ion_types : str
         Fragment ion types to annotate, e.g. ``"by"``.
+    max_charge : int or None
+        Maximum fragment ion charge to annotate. ``None`` uses the
+        spectrum_utils default (the precursor charge).
+    max_isotope : int
+        Maximum isotope number to annotate for each fragment ion.
+    title : str or None
+        Optional title for the plot. A note that the top spectrum is the
+        prediction and the bottom is the ground truth is always appended.
     """
     top = _annotated_spectrum(
-        mztab, peak_file, index, fragment_tol, fragment_tol_mode, ion_types
+        mztab,
+        peak_file,
+        index,
+        fragment_tol,
+        fragment_tol_mode,
+        ion_types,
+        max_charge,
+        max_isotope,
     )
     bottom = _annotated_spectrum(
         ground_truth_mztab,
@@ -187,9 +250,13 @@ def mirror(
         fragment_tol,
         fragment_tol_mode,
         ion_types,
+        max_charge,
+        max_isotope,
     )
     fig, ax = plt.subplots(figsize=(12, 6))
     sup.mirror(top, bottom, ax=ax)
+    gt_label = "Top: predicted, bottom: ground truth"
+    ax.set_title(f"{title}\n{gt_label}" if title else gt_label)
     fig.savefig(out, dpi=300, bbox_inches="tight")
     plt.close(fig)
     print(f"Wrote {out}", file=sys.stderr)

--- a/src/casanovoutils/plot.py
+++ b/src/casanovoutils/plot.py
@@ -1,0 +1,198 @@
+"""Plot annotated spectra and mirror plots from Casanovo mzTab results."""
+
+import sys
+
+import matplotlib.pyplot as plt
+import polars as pl
+import pyteomics.mgf
+import pyteomics.mzml
+import spectrum_utils.plot as sup
+import spectrum_utils.spectrum as sus
+
+from .denovoutils import DfPath, get_mztab_df
+from .types import Commands
+
+_PROFORMA_COLUMN = "mztab_opt_global_cv_MS:1003169_proforma_peptidoform_sequence"
+
+
+def _read_spectrum(peak_file: str, index: int) -> sus.MsmsSpectrum:
+    """
+    Read the spectrum at a zero-based index from an MGF or mzML file.
+
+    Parameters
+    ----------
+    peak_file : str
+        Path to the MGF or mzML peak file.
+    index : int
+        Zero-based index of the spectrum, matching the ``index=N`` value
+        in the mzTab ``spectra_ref`` column.
+
+    Returns
+    -------
+    sus.MsmsSpectrum
+        The spectrum with its m/z, intensity, and precursor information.
+    """
+    peak_file = str(peak_file)
+    if peak_file.lower().endswith((".mzml", ".mzml.gz")):
+        with pyteomics.mzml.MzML(peak_file) as reader:
+            spectrum = reader[index]
+        ion = spectrum["precursorList"]["precursor"][0]["selectedIonList"][
+            "selectedIon"
+        ][0]
+        precursor_mz = float(ion["selected ion m/z"])
+        precursor_charge = int(ion.get("charge state", 0))
+    else:
+        with pyteomics.mgf.IndexedMGF(peak_file) as reader:
+            spectrum = reader[index]
+        params = spectrum["params"]
+        precursor_mz = float(params["pepmass"][0])
+        charge = params.get("charge")
+        precursor_charge = int(charge[0]) if charge else 0
+    return sus.MsmsSpectrum(
+        str(index),
+        precursor_mz,
+        precursor_charge,
+        spectrum["m/z array"],
+        spectrum["intensity array"],
+    )
+
+
+def _peptide_at_index(mztab_df: pl.DataFrame, index: int) -> str:
+    """
+    Return the ProForma peptide for the spectrum at a zero-based index.
+
+    Parameters
+    ----------
+    mztab_df : pl.DataFrame
+        The mzTab spectrum match table, as returned by ``get_mztab_df``.
+    index : int
+        Zero-based spectrum index to look up in ``spectra_ref``.
+
+    Returns
+    -------
+    str
+        The ProForma peptide string for the matching PSM.
+    """
+    column = (
+        _PROFORMA_COLUMN if _PROFORMA_COLUMN in mztab_df.columns else "mztab_sequence"
+    )
+    matches = mztab_df.filter(
+        pl.col("mztab_spectra_ref").str.ends_with(f"index={index}")
+    )
+    if matches.is_empty():
+        raise ValueError(f"No PSM found for spectrum index {index}")
+    return matches[column][0]
+
+
+def _annotated_spectrum(
+    mztab: DfPath,
+    peak_file: str,
+    index: int,
+    fragment_tol: float,
+    fragment_tol_mode: str,
+    ion_types: str,
+) -> sus.MsmsSpectrum:
+    """Build the annotated spectrum for a PSM in an mzTab file."""
+    peptide = _peptide_at_index(get_mztab_df(mztab), index)
+    spectrum = _read_spectrum(peak_file, index)
+    spectrum.annotate_proforma(
+        peptide, fragment_tol, fragment_tol_mode, ion_types=ion_types
+    )
+    return spectrum
+
+
+def spectrum(
+    mztab: DfPath,
+    peak_file: str,
+    index: int,
+    out: str = "spectrum.png",
+    fragment_tol: float = 0.5,
+    fragment_tol_mode: str = "Da",
+    ion_types: str = "by",
+) -> None:
+    """
+    Plot a single annotated spectrum from a Casanovo mzTab result.
+
+    Parameters
+    ----------
+    mztab : DfPath
+        Path to the Casanovo mzTab file.
+    peak_file : str
+        Path to the MGF or mzML peak file the spectra were sequenced from.
+    index : int
+        Zero-based index of the spectrum to plot (the ``index=N`` value in
+        the mzTab ``spectra_ref`` column).
+    out : str
+        Output image path.
+    fragment_tol : float
+        Fragment mass tolerance for annotation.
+    fragment_tol_mode : str
+        Fragment mass tolerance mode, ``"Da"`` or ``"ppm"``.
+    ion_types : str
+        Fragment ion types to annotate, e.g. ``"by"``.
+    """
+    spec = _annotated_spectrum(
+        mztab, peak_file, index, fragment_tol, fragment_tol_mode, ion_types
+    )
+    fig, ax = plt.subplots(figsize=(12, 6))
+    sup.spectrum(spec, ax=ax)
+    fig.savefig(out, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {out}", file=sys.stderr)
+
+
+def mirror(
+    mztab: DfPath,
+    peak_file: str,
+    index: int,
+    ground_truth_mztab: DfPath,
+    out: str = "mirror.png",
+    fragment_tol: float = 0.5,
+    fragment_tol_mode: str = "Da",
+    ion_types: str = "by",
+) -> None:
+    """
+    Plot a mirror plot of a predicted versus a ground truth annotation.
+
+    The predicted peptide (from ``mztab``) is annotated on the top spectrum
+    and the ground truth peptide (from ``ground_truth_mztab``) on the
+    bottom, using the same peaks from ``peak_file``.
+
+    Parameters
+    ----------
+    mztab : DfPath
+        Path to the Casanovo mzTab file with the predicted peptides.
+    peak_file : str
+        Path to the MGF or mzML peak file.
+    index : int
+        Zero-based index of the spectrum to plot.
+    ground_truth_mztab : DfPath
+        Path to an mzTab file with the ground truth peptides.
+    out : str
+        Output image path.
+    fragment_tol : float
+        Fragment mass tolerance for annotation.
+    fragment_tol_mode : str
+        Fragment mass tolerance mode, ``"Da"`` or ``"ppm"``.
+    ion_types : str
+        Fragment ion types to annotate, e.g. ``"by"``.
+    """
+    top = _annotated_spectrum(
+        mztab, peak_file, index, fragment_tol, fragment_tol_mode, ion_types
+    )
+    bottom = _annotated_spectrum(
+        ground_truth_mztab,
+        peak_file,
+        index,
+        fragment_tol,
+        fragment_tol_mode,
+        ion_types,
+    )
+    fig, ax = plt.subplots(figsize=(12, 6))
+    sup.mirror(top, bottom, ax=ax)
+    fig.savefig(out, dpi=300, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Wrote {out}", file=sys.stderr)
+
+
+COMMANDS: Commands = {"spectrum": spectrum, "mirror": mirror}

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -8,14 +8,15 @@ import polars as pl
 import pytest
 
 from casanovoutils import plot
+from casanovoutils.constants import Constants
 
 
-def _write_mgf(path):
+def _write_mgf(path, charge="CHARGE=2+\n"):
     path.write_text(
         "BEGIN IONS\n"
         "TITLE=s0\n"
         "PEPMASS=500.0\n"
-        "CHARGE=2+\n"
+        f"{charge}"
         "100.0 1.0\n"
         "200.0 2.0\n"
         "300.0 3.0\n"
@@ -23,11 +24,11 @@ def _write_mgf(path):
     )
 
 
-def _mztab(peptide):
+def _mztab(peptide, index=0):
     return pl.DataFrame(
         {
-            "mztab_spectra_ref": ["ms_run[1]:index=0"],
-            plot._PROFORMA_COLUMN: [peptide],
+            "mztab_spectra_ref": [f"ms_run[1]:index={index}"],
+            Constants.proforma_column: [peptide],
         }
     )
 
@@ -51,3 +52,54 @@ def test_mirror_plot(tmp_path):
 def test_peptide_at_index_missing():
     with pytest.raises(ValueError):
         plot._peptide_at_index(_mztab("PEPTIDEK"), 5)
+
+
+def test_read_spectrum_no_charge_warns(tmp_path):
+    mgf = tmp_path / "nocharge.mgf"
+    _write_mgf(mgf, charge="")
+    with pytest.warns(UserWarning, match="No precursor charge"):
+        spec = plot._read_spectrum(str(mgf), 0)
+    assert spec.precursor_charge == 0
+
+
+def test_peptide_at_index_multiple_warns():
+    df = pl.DataFrame(
+        {
+            "mztab_spectra_ref": ["ms_run[1]:index=0", "ms_run[1]:index=0"],
+            Constants.proforma_column: ["PEPTIDEK", "PEPTIDER"],
+        }
+    )
+    with pytest.warns(UserWarning, match="Multiple PSMs"):
+        peptide = plot._peptide_at_index(df, 0)
+    assert peptide == "PEPTIDEK"
+
+
+def test_spectrum_title_and_annotation_params(tmp_path):
+    mgf = tmp_path / "test.mgf"
+    _write_mgf(mgf)
+    out = tmp_path / "spectrum.png"
+    plot.spectrum(
+        _mztab("PEPTIDEK"),
+        str(mgf),
+        0,
+        out=str(out),
+        max_charge=1,
+        max_isotope=1,
+        title="My spectrum",
+    )
+    assert out.is_file()
+
+
+def test_mirror_title(tmp_path):
+    mgf = tmp_path / "test.mgf"
+    _write_mgf(mgf)
+    out = tmp_path / "mirror.png"
+    plot.mirror(
+        _mztab("PEPTIDEK"),
+        str(mgf),
+        0,
+        _mztab("PEPTIDER"),
+        out=str(out),
+        title="My mirror",
+    )
+    assert out.is_file()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,0 +1,53 @@
+"""Tests for the spectrum plotting commands."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import polars as pl
+import pytest
+
+from casanovoutils import plot
+
+
+def _write_mgf(path):
+    path.write_text(
+        "BEGIN IONS\n"
+        "TITLE=s0\n"
+        "PEPMASS=500.0\n"
+        "CHARGE=2+\n"
+        "100.0 1.0\n"
+        "200.0 2.0\n"
+        "300.0 3.0\n"
+        "END IONS\n"
+    )
+
+
+def _mztab(peptide):
+    return pl.DataFrame(
+        {
+            "mztab_spectra_ref": ["ms_run[1]:index=0"],
+            plot._PROFORMA_COLUMN: [peptide],
+        }
+    )
+
+
+def test_spectrum_plot(tmp_path):
+    mgf = tmp_path / "test.mgf"
+    _write_mgf(mgf)
+    out = tmp_path / "spectrum.png"
+    plot.spectrum(_mztab("PEPTIDEK"), str(mgf), 0, out=str(out))
+    assert out.is_file()
+
+
+def test_mirror_plot(tmp_path):
+    mgf = tmp_path / "test.mgf"
+    _write_mgf(mgf)
+    out = tmp_path / "mirror.png"
+    plot.mirror(_mztab("PEPTIDEK"), str(mgf), 0, _mztab("PEPTIDER"), out=str(out))
+    assert out.is_file()
+
+
+def test_peptide_at_index_missing():
+    with pytest.raises(ValueError):
+        plot._peptide_at_index(_mztab("PEPTIDEK"), 5)


### PR DESCRIPTION
Fixes #7.

Adds two plotting commands built on spectrum_utils, driven by a Casanovo mzTab result and its peak file:

- `casanovoutils plot spectrum` — annotated spectrum for a single result
- `casanovoutils plot mirror` — mirror plot of the predicted peptide against a ground-truth annotation

The peptide is read from the mzTab ProForma column and matched to peaks by spectrum index. Adds `spectrum-utils>=0.4.2` as a dependency, plus tests covering spectrum reading, peptide lookup, and both commands.